### PR TITLE
소셜로그인 구현 완료(Kakao, Google)

### DIFF
--- a/src/main/java/team9499/commitbody/domain/Member/domain/Gender.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/Gender.java
@@ -1,0 +1,25 @@
+package team9499.commitbody.domain.Member.domain;
+
+public enum Gender {
+
+    MALE("남성"),
+    FEMALE("여성");
+
+    private final String genderKR;
+
+    Gender(String genderKR) {
+        this.genderKR = genderKR;
+    }
+    public String getGenderKR(){
+        return genderKR;
+    }
+
+    public static Gender fromGenderKR(String genderKR) {
+        for (Gender gender : values()) {
+            if (gender.getGenderKR().equals(genderKR)) {
+                return gender;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/Member/domain/GenderConverter.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/GenderConverter.java
@@ -1,0 +1,17 @@
+package team9499.commitbody.domain.Member.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class GenderConverter implements AttributeConverter<Gender,String> {
+    @Override
+    public String convertToDatabaseColumn(Gender attribute) {
+        return attribute == null ? null : attribute.getGenderKR();
+    }
+
+    @Override
+    public Gender convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : Gender.fromGenderKR(dbData);
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
@@ -7,6 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import team9499.commitbody.global.utils.BaseTime;
 
+import java.time.LocalDate;
+
 @Entity
 @Data
 @Builder
@@ -26,19 +28,21 @@ public class Member extends BaseTime {
 
     private String weight;      // 몸무게
 
-    private String birthday;    // 생년월일
+    private LocalDate birthday;    // 생년월일
 
-    private Integer sex;         // 성별 (남 : 0, 여 : 1)
+    @Convert(converter = GenderConverter.class)
+    private Gender gender;         // 성별 (남 : 0, 여 : 1)
 
     private String email;       // 이메일
 
-    private float BoneMineralDensity; // 골극격량
+    private Float BoneMineralDensity; // 골극격량
 
-    private float BodyFatPercentage; // 체지방량
+    private Float BodyFatPercentage; // 체지방량
 
     private boolean notificationEnabled; //알림 유무
 
-    private Integer weightUnit; // 무게 타입 (KG : 1, LB : 0)
+    @Enumerated(EnumType.STRING)
+    private WeightUnit weightUnit; // 무게 타입 (KG : 1, LB : 0)
 
     @Enumerated(EnumType.STRING)
     private LoginType loginType;        //로그인 타입 (KAKAO, GOOGLE)
@@ -47,5 +51,25 @@ public class Member extends BaseTime {
 
     public static Member createSocialId(String socialId,LoginType loginType){
         return Member.builder().socialId(socialId).loginType(loginType).build();
+    }
+
+    public void createAdditionalInfoNotNull(String nickName, Gender gender, LocalDate birthday, String height, String weight,float boneMineralDensity, float bodyFatPercentage){
+        this.nickname = nickName;
+        this.gender = gender;
+        this.birthday = birthday;
+        this.height = height;
+        this.weight = weight;
+        this.BoneMineralDensity = boneMineralDensity;
+        this.BodyFatPercentage = bodyFatPercentage;
+        this.weightUnit = WeightUnit.KG;
+    }
+
+    public void createAdditionalInfoNull(String nickName, Gender gender, LocalDate birthday, String height, String weight){
+        this.nickname = nickName;
+        this.gender = gender;
+        this.birthday = birthday;
+        this.height = height;
+        this.weight = weight;
+        this.weightUnit = WeightUnit.KG;
     }
 }

--- a/src/main/java/team9499/commitbody/domain/Member/domain/WeightUnit.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/WeightUnit.java
@@ -1,0 +1,5 @@
+package team9499.commitbody.domain.Member.domain;
+
+public enum WeightUnit {
+    KG, LB
+}

--- a/src/main/java/team9499/commitbody/domain/Member/dto/MemberDto.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/MemberDto.java
@@ -5,7 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import team9499.commitbody.domain.Member.domain.Gender;
 import team9499.commitbody.domain.Member.domain.LoginType;
+import team9499.commitbody.domain.Member.domain.WeightUnit;
+
+import java.time.LocalDate;
 
 @Data
 @Builder
@@ -24,19 +28,19 @@ public class MemberDto {
 
     private String weight;      // 몸무게
 
-    private String birthday;    // 생년월일
+    private LocalDate birthday;    // 생년월일
 
-    private Integer sex;         // 성별 (남 : 0, 여 : 1)
+    private Gender gender;         // 성별(MALE, FEMALE)
 
     private String email;       // 이메일
 
-    private float BoneMineralDensity; // 골극격량
+    private Float BoneMineralDensity; // 골극격량
 
-    private float BodyFatPercentage; // 체지방량
+    private Float BodyFatPercentage; // 체지방량
 
     private boolean notificationEnabled; //알림 유무
 
-    private Integer weightUnit; // 무게 타입 (KG : 1, LB : 0)
+    private WeightUnit weightUnit; // 무게 타입 (KG, LB)
 
     private LoginType loginType;        //로그인 타입 (KAKAO, GOOGLE)
 

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionAdvice.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionAdvice.java
@@ -1,5 +1,6 @@
 package team9499.commitbody.global.Exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,13 +13,20 @@ public class ExceptionAdvice {
     public ResponseEntity<ErrorResponse> serverException(ServerException e){
         ErrorResponse er = new ErrorResponse<>(false, e.getMessage());
         e.printStackTrace();
-        return ResponseEntity.status(500).body(er);
+        return ResponseEntity.status(e.getExceptionStatus()).body(er);
     }
 
     @ExceptionHandler
     public ResponseEntity<ErrorResponse> noSuchException(NoSuchException e){
         ErrorResponse er = new ErrorResponse(false, e.getMessage());
         e.printStackTrace();
-        return ResponseEntity.status(400).body(er);
+        return ResponseEntity.status(e.getExceptionStatus()).body(er);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> jwtTokenException(JwtTokenException e){
+        ErrorResponse er = new ErrorResponse(false, e.getMessage());
+        e.printStackTrace();
+        return ResponseEntity.status(e.getExceptionStatus()).body(er);
     }
 }

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionStatus.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionStatus.java
@@ -1,0 +1,19 @@
+package team9499.commitbody.global.Exception;
+
+public enum ExceptionStatus {
+
+    BAD_REQUEST(400),
+    UNAUTHORIZED(401),
+    FORBIDDEN(403),
+    SERVER_ERROR(500);
+
+    private final int status;
+
+    ExceptionStatus(int status) {
+        this.status = status;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionType.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionType.java
@@ -4,7 +4,9 @@ public enum ExceptionType {
 
     SERVER_ERROR("서버 오류가 발생했습니다."),
     NO_SUCH_DATA("해당 정보를 찾을수 없습니다."),
-    No_SUCH_MEMBER("사용자를 찾을수 없습니다.");
+    No_SUCH_MEMBER("사용자를 찾을수 없습니다."),
+    TOKEN_NOT_FOUND("토큰이 존재하지 않습니다."),
+    INVALID_TOKEN_MESSAGE("사용할 수 없는 토큰입니다.");
 
 
     private final String message;

--- a/src/main/java/team9499/commitbody/global/Exception/JwtTokenException.java
+++ b/src/main/java/team9499/commitbody/global/Exception/JwtTokenException.java
@@ -1,13 +1,14 @@
 package team9499.commitbody.global.Exception;
 
-public class ServerException extends RuntimeException{
+public class JwtTokenException extends RuntimeException{
 
     private final ExceptionType exceptionType;
     private final ExceptionStatus exceptionStatus;
-    public ServerException(ExceptionStatus exceptionStatus,ExceptionType exceptionType) {
+
+    public JwtTokenException(ExceptionStatus exceptionStatus, ExceptionType exceptionType) {
         super(exceptionType.getMessage());
+        this.exceptionStatus = exceptionStatus;
         this.exceptionType = exceptionType;
-        this.exceptionStatus=exceptionStatus;
     }
 
     public int getExceptionStatus() {

--- a/src/main/java/team9499/commitbody/global/Exception/NoSuchException.java
+++ b/src/main/java/team9499/commitbody/global/Exception/NoSuchException.java
@@ -3,9 +3,15 @@ package team9499.commitbody.global.Exception;
 public class NoSuchException extends RuntimeException{
 
     private final ExceptionType exceptionType;
+    private final ExceptionStatus exceptionStatus;
 
-    public NoSuchException(ExceptionType exceptionType) {
+    public NoSuchException(ExceptionStatus exceptionStatus, ExceptionType exceptionType) {
         super(exceptionType.getMessage());
         this.exceptionType = exceptionType;
+        this.exceptionStatus = exceptionStatus;
+    }
+
+    public int getExceptionStatus() {
+        return exceptionStatus.getStatus();
     }
 }

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -19,6 +19,7 @@ import team9499.commitbody.domain.Member.domain.LoginType;
 import team9499.commitbody.global.authorization.dto.AdditionalInfoReqeust;
 import team9499.commitbody.global.authorization.dto.TokenUserInfoResponse;
 import team9499.commitbody.global.authorization.service.AuthorizationService;
+import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
 
 import java.util.LinkedHashMap;
@@ -37,9 +38,12 @@ public class AuthorizationController {
 
     @Operation(summary = "회원가입/로그인", description = "매 요청마다 OpenID를 type에 전달합니다. 최초 로그인 시에는 회원가입이 진행되며, 이후 로그인이 진행됩니다. 로그인 시에만 tokenInfo에 사용자 정보가 포함됩니다.(authMode: [로그인,회원가입])")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",description = "0K",
-            content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"성공\",\"data\":{\"refreshToken\":\"sample_refresh_token\",\"accessToken\":\"sample_access_token\",\"authMode\":\"타입 종류\",\"tokenInfo\":{\"memberId\":1}}}")))
+            @ApiResponse(responseCode = "200",description = "0K", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"성공\",\"data\":{\"refreshToken\":\"sample_refresh_token\",\"accessToken\":\"sample_access_token\",\"authMode\":\"타입 종류\",\"tokenInfo\":{\"memberId\":1}}}"))),
+            @ApiResponse(responseCode = "400",description = "BADREQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401",description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+            examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
     })
     @PostMapping("/auth")
     public ResponseEntity<SuccessResponse> socialLogin(@RequestParam("type")LoginType loginType,
@@ -53,10 +57,16 @@ public class AuthorizationController {
 
     @Operation(summary = "회원가입-추가정보", description = "회원가입의 필요한 추가 개인정보를 작성합니다. 추가정보 입력 완료시 tokenInfo에 사용자 정보가 포함됩니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200",description = "0K",
-                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"회원가입 성공\",\"data\":{\"tokenInfo\":{\"memberId\":1}}}")))
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"회원가입 성공\",\"data\":{\"tokenInfo\":{\"memberId\":1}}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 값 입렵 검증", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"실패\",\"data\":{\"필드명\": \"오류 내용\"}}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                            examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
     })
+
     @PostMapping("/additional-info")
     public ResponseEntity<?> additionalInfo(@Valid @RequestBody AdditionalInfoReqeust additionalInfoReqeust, BindingResult result,HttpServletRequest request){
         if (result.hasErrors()){
@@ -64,7 +74,7 @@ public class AuthorizationController {
             for(FieldError error : result.getFieldErrors()){
                 errorMap.put(error.getField(),error.getDefaultMessage());
             }
-            return ResponseEntity.status(BAD_REQUEST).body(errorMap);
+            return ResponseEntity.status(BAD_REQUEST).body(new ErrorResponse<>(false,"실패",errorMap));
         }
 
         String jwtToken = getJwtToken(request);

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -1,15 +1,33 @@
 package team9499.commitbody.global.authorization.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.Member.domain.LoginType;
+import team9499.commitbody.global.authorization.dto.AdditionalInfoReqeust;
+import team9499.commitbody.global.authorization.dto.TokenUserInfoResponse;
 import team9499.commitbody.global.authorization.service.AuthorizationService;
 import team9499.commitbody.global.payload.SuccessResponse;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.springframework.http.HttpStatus.*;
+
+@Tag(name = "인증 인가",description = "인증 인가관련된 API")
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -17,16 +35,46 @@ public class AuthorizationController {
 
     private final AuthorizationService authorizationService;
 
+    @Operation(summary = "회원가입/로그인", description = "매 요청마다 OpenID를 type에 전달합니다. 최초 로그인 시에는 회원가입이 진행되며, 이후 로그인이 진행됩니다. 로그인 시에만 tokenInfo에 사용자 정보가 포함됩니다.(authMode: [로그인,회원가입])")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",description = "0K",
+            content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"성공\",\"data\":{\"refreshToken\":\"sample_refresh_token\",\"accessToken\":\"sample_access_token\",\"authMode\":\"타입 종류\",\"tokenInfo\":{\"memberId\":1}}}")))
+    })
     @PostMapping("/auth")
-    public ResponseEntity<?> socialLogin(@RequestParam("type")LoginType loginType,
+    public ResponseEntity<SuccessResponse> socialLogin(@RequestParam("type")LoginType loginType,
                                          HttpServletRequest request){
         String jwtToken = getJwtToken(request);
 
-        Map<String, String> jwtTokenMap = authorizationService.authenticateOrRegisterUser(loginType, jwtToken);
+        Map<String, Object> jwtTokenMap = authorizationService.authenticateOrRegisterUser(loginType, jwtToken);
 
         return ResponseEntity.ok().body(new SuccessResponse<>(true,"성공",jwtTokenMap));
     }
 
+    @Operation(summary = "회원가입-추가정보", description = "회원가입의 필요한 추가 개인정보를 작성합니다. 추가정보 입력 완료시 tokenInfo에 사용자 정보가 포함됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",description = "0K",
+                    content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"회원가입 성공\",\"data\":{\"tokenInfo\":{\"memberId\":1}}}")))
+    })
+    @PostMapping("/additional-info")
+    public ResponseEntity<?> additionalInfo(@Valid @RequestBody AdditionalInfoReqeust additionalInfoReqeust, BindingResult result,HttpServletRequest request){
+        if (result.hasErrors()){
+            Map<String,String> errorMap = new LinkedHashMap<>();
+            for(FieldError error : result.getFieldErrors()){
+                errorMap.put(error.getField(),error.getDefaultMessage());
+            }
+            return ResponseEntity.status(BAD_REQUEST).body(errorMap);
+        }
+
+        String jwtToken = getJwtToken(request);
+
+        TokenUserInfoResponse tokenUserInfoResponse = authorizationService.additionalInfoSave(
+                additionalInfoReqeust.getNickName(), additionalInfoReqeust.getGender(), additionalInfoReqeust.getBirthday(), additionalInfoReqeust.getHeight(), additionalInfoReqeust.getWeight(),
+                additionalInfoReqeust.getBodyFatPercentage(), additionalInfoReqeust.getBoneMineralDensity(), jwtToken
+        );
+        return ResponseEntity.ok(new SuccessResponse(true,"회원가입 성공",tokenUserInfoResponse));
+    }
 
     private static String getJwtToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");

--- a/src/main/java/team9499/commitbody/global/authorization/dto/AdditionalInfoReqeust.java
+++ b/src/main/java/team9499/commitbody/global/authorization/dto/AdditionalInfoReqeust.java
@@ -1,0 +1,43 @@
+package team9499.commitbody.global.authorization.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import lombok.Data;
+import team9499.commitbody.domain.Member.domain.Gender;
+
+import java.time.LocalDate;
+
+@Data
+@Schema(name = "추가정보 입력 Request")
+public class AdditionalInfoReqeust {
+
+    @Schema(description = "사용자 닉네임")
+    @NotBlank(message = "닉네임을 작성해주세요")
+    private String nickName;
+    
+    @Schema(description = "FEMALE : 여성, MALE : 남성")
+    @NotNull(message = "성별을 입력해주세요")
+    private Gender gender;
+
+    @Schema(description = "생년월일의 형식은 2024-08-03(yyyy-MM-dd) 형식으로 보내야하며, 가입일 기준 일부터 가입이 가능")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Past(message = "생일은 오늘보다 이전이어야 합니다.")
+    private LocalDate birthday;
+
+    @Schema(description = "사용자 키")
+    @NotBlank(message = "키를 입력해주세요")
+    private String height;
+
+    @Schema(description = "사용자 몸무게")
+    @NotBlank(message = "몸무게를 입력해주세요")
+    private String weight;
+
+    @Schema(description = "필수값이 아닙니다.")
+    private Float boneMineralDensity;   // 골격근량
+
+    @Schema(description = "필수값이 아닙니다.")
+    private Float bodyFatPercentage;    //체지방량
+}

--- a/src/main/java/team9499/commitbody/global/authorization/dto/TokenInfoDto.java
+++ b/src/main/java/team9499/commitbody/global/authorization/dto/TokenInfoDto.java
@@ -1,0 +1,19 @@
+package team9499.commitbody.global.authorization.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class TokenInfoDto {
+
+    private Long memberId;
+
+    private TokenInfoDto(Long memberId) {
+        this.memberId = memberId;
+    }
+
+    public static TokenInfoDto of(Long memberId){
+        return new TokenInfoDto(memberId);
+    }
+}

--- a/src/main/java/team9499/commitbody/global/authorization/dto/TokenUserInfoResponse.java
+++ b/src/main/java/team9499/commitbody/global/authorization/dto/TokenUserInfoResponse.java
@@ -1,0 +1,14 @@
+package team9499.commitbody.global.authorization.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TokenUserInfoResponse {
+
+    private TokenInfoDto tokenInfo;
+
+}

--- a/src/main/java/team9499/commitbody/global/authorization/service/AuthorizationService.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/AuthorizationService.java
@@ -1,11 +1,15 @@
 package team9499.commitbody.global.authorization.service;
 
-
+import team9499.commitbody.domain.Member.domain.Gender;
 import team9499.commitbody.domain.Member.domain.LoginType;
+import team9499.commitbody.global.authorization.dto.TokenUserInfoResponse;
 
+import java.time.LocalDate;
 import java.util.Map;
 
 public interface AuthorizationService {
 
-    Map<String,String> authenticateOrRegisterUser(LoginType loginType,String socialJwt);
+    Map<String,Object> authenticateOrRegisterUser(LoginType loginType,String socialJwt);
+
+    TokenUserInfoResponse additionalInfoSave(String nickName, Gender gender, LocalDate birthday, String height, String weight, Float boneMineralDensity, Float bodyFatPercentage, String jwtToken);
 }

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/GoogleOpenIdConnectServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/GoogleOpenIdConnectServiceImpl.java
@@ -2,6 +2,9 @@ package team9499.commitbody.global.authorization.service.impl;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.AlgorithmMismatchException;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.JWK;
@@ -10,7 +13,7 @@ import com.nimbusds.jose.jwk.RSAKey;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
-import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.Exception.JwtTokenException;
 import team9499.commitbody.global.Exception.NoSuchException;
 import team9499.commitbody.global.authorization.service.OpenIdConnectService;
 import team9499.commitbody.global.redis.RedisService;
@@ -21,6 +24,9 @@ import java.net.URL;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.util.List;
+
+import static team9499.commitbody.global.Exception.ExceptionStatus.*;
+import static team9499.commitbody.global.Exception.ExceptionType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -45,7 +51,7 @@ public class GoogleOpenIdConnectServiceImpl implements OpenIdConnectService {
             String keyId = decodedJWT.getKeyId();
 
             JWK jwk = keys.stream().filter(key -> key.getKeyID().equals(keyId))
-                    .findFirst().orElseThrow(() -> new NoSuchException(ExceptionType.NO_SUCH_DATA));
+                    .findFirst().orElseThrow(() -> new NoSuchException(BAD_REQUEST,NO_SUCH_DATA));
 
             rsaPublicKey = getPublicKeyFromJWK(jwk);
 
@@ -55,10 +61,21 @@ public class GoogleOpenIdConnectServiceImpl implements OpenIdConnectService {
             rsaPublicKey = PublicKeyUtils.StringToPublicKey(redisPublicKey);
 
         Algorithm rsa256 = Algorithm.RSA256(rsaPublicKey, null);
-        DecodedJWT verify = JWT.require(rsa256).build().verify(socialJwtToken);
+        DecodedJWT verify = getVerify(socialJwtToken, rsa256);
         return verify.getClaim("sub").asString();
     }
 
+    private static DecodedJWT getVerify(String socialJwtToken, Algorithm rsa256) {
+        try {
+            return JWT.require(rsa256).build().verify(socialJwtToken);
+        }catch (AlgorithmMismatchException e){
+            throw new JwtTokenException(UNAUTHORIZED,TOKEN_NOT_FOUND);
+        }catch (JWTDecodeException e){
+            throw new JwtTokenException(BAD_REQUEST,INVALID_TOKEN_MESSAGE);
+        }catch (SignatureVerificationException e){
+            throw new JwtTokenException(UNAUTHORIZED,TOKEN_NOT_FOUND);
+        }
+    }
     private JWKSet loadJWKSet(String url) {
         try {
             return JWKSet.load(new URL(url));

--- a/src/main/java/team9499/commitbody/global/config/SecurityConfig.java
+++ b/src/main/java/team9499/commitbody/global/config/SecurityConfig.java
@@ -28,8 +28,10 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
-                        .requestMatchers("/api/v1/auth","/actuator/**","/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html","/api-docs/**").permitAll()
-                        .requestMatchers("/api/v1/**").hasRole("USER"));
+                        .requestMatchers("/api/v1/auth","/actuator/**","/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html","/api-docs/**",
+                                "/api/v1/additional-info"
+                                ).permitAll()
+                        .requestMatchers("/api/v1/**").hasAnyRole("USER"));
         return http.build();
     }
 

--- a/src/main/java/team9499/commitbody/global/utils/JwtUtils.java
+++ b/src/main/java/team9499/commitbody/global/utils/JwtUtils.java
@@ -3,15 +3,24 @@ package team9499.commitbody.global.utils;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.AlgorithmMismatchException;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import team9499.commitbody.domain.Member.dto.MemberDto;
+import team9499.commitbody.global.Exception.JwtTokenException;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.Map;
 
+import static team9499.commitbody.global.Exception.ExceptionStatus.*;
+import static team9499.commitbody.global.Exception.ExceptionType.*;
+
+@Slf4j
 @Component
 public class JwtUtils {
 
@@ -57,7 +66,47 @@ public class JwtUtils {
     private String creatToken(MemberDto memberDto, Date expirationDate) {
         return  JWT.create()
                 .withExpiresAt(expirationDate)
-                .withClaim(MEMBER_ID, memberDto.getMemberId())
+                .withClaim(MEMBER_ID, String.valueOf(memberDto.getMemberId()))
                 .sign(Algorithm.HMAC512(SECRET));
+    }
+
+    public String accessTokenValid(String jwtToken){
+        try {
+            if (!tokenExpiration(jwtToken)) {
+                return verifyToken(jwtToken);
+            }
+            return null;
+        } catch (SignatureVerificationException e) {
+            log.error("존재하지 않은 토큰 사용");
+            throw new JwtTokenException(UNAUTHORIZED, TOKEN_NOT_FOUND);
+        }
+    }
+
+    /*
+    토큰의 정보를 추출하는 메서드
+     */
+    public String verifyToken(String tokenValue) {
+        try {
+            return JWT.require(Algorithm.HMAC512(SECRET)).build()
+                    .verify(tokenValue)
+                    .getClaim(MEMBER_ID)
+                    .asString();
+        }catch (AlgorithmMismatchException e){
+            throw new JwtTokenException(BAD_REQUEST,TOKEN_NOT_FOUND);
+        }
+
+    }
+
+    /*
+    토큰의 대한 시간 검증 (true : 토큰 만료 , false : 토큰 유효)
+     */
+    public Boolean tokenExpiration(String token) {
+        try {
+            Date expired = JWT.decode(token).getExpiresAt();
+            return expired != null && expired.before(new Date());
+        }catch (JWTDecodeException e){
+            throw new JwtTokenException(BAD_REQUEST,INVALID_TOKEN_MESSAGE);
+        }
+
     }
 }

--- a/src/main/java/team9499/commitbody/global/utils/PublicKeyUtils.java
+++ b/src/main/java/team9499/commitbody/global/utils/PublicKeyUtils.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.global.utils;
 
 import lombok.extern.slf4j.Slf4j;
+import team9499.commitbody.global.Exception.ExceptionStatus;
 import team9499.commitbody.global.Exception.ExceptionType;
 import team9499.commitbody.global.Exception.ServerException;
 
@@ -10,6 +11,8 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
+
+import static team9499.commitbody.global.Exception.ExceptionStatus.*;
 
 @Slf4j
 public class PublicKeyUtils {
@@ -47,7 +50,7 @@ public class PublicKeyUtils {
             return (RSAPublicKey) keyFactory.generatePublic(keySpec);
         } catch (InvalidKeySpecException e) {
             log.error("공개키 생성 도중 오류 발생");
-            throw new ServerException(ExceptionType.SERVER_ERROR);
+            throw new ServerException(SERVER_ERROR,ExceptionType.SERVER_ERROR);
         }
     }
     
@@ -59,7 +62,7 @@ public class PublicKeyUtils {
             return KeyFactory.getInstance(type);
         } catch (NoSuchAlgorithmException e) {
             log.error("공개키 변환 과정중 오류 발생");
-            throw new ServerException(ExceptionType.SERVER_ERROR);
+            throw new ServerException(SERVER_ERROR,ExceptionType.SERVER_ERROR);
         }
     }
 }

--- a/src/test/java/team9499/commitbody/global/authorization/controller/AuthorizationControllerTest.java
+++ b/src/test/java/team9499/commitbody/global/authorization/controller/AuthorizationControllerTest.java
@@ -1,0 +1,41 @@
+package team9499.commitbody.global.authorization.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import team9499.commitbody.domain.Member.domain.LoginType;
+import team9499.commitbody.global.authorization.service.AuthorizationService;
+import team9499.commitbody.global.config.SecurityConfig;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@Import(SecurityConfig.class)
+@WebMvcTest(AuthorizationController.class)
+class AuthorizationControllerTest {
+
+    @MockBean
+    AuthorizationService authorizationService;
+    @Autowired MockMvc mockMvc;
+
+    @Test
+    void socialLogin() throws Exception {
+        String fakeToken ="Bearer eyJraWQiOiI5ZjI1MmRhZGQ1ZjIzM2Y5M2QyZmE1MjhkMTJmZWEiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJjMGY1MzBhOGMyYmQwOGFiZGUzYTE5YTlkYmY2M2EyNyIsInN1YiI6IjMyODEyODI5NTciLCJhdXRoX3RpbWUiOjE3MjI1NDE5NjIsImlzcyI6Imh0dHBzOi8va2F1dGgua2FrYW8uY29tIiwibmlja25hbWUiOiLrr7zsmrAiLCJleHAiOjE3MjI1NjM1NjIsImlhdCI6MTcyMjU0MTk2MiwiZW1haWwiOiJrZXV5ZTYwMzhAbmF2ZXIuY29tIn0.hDSwIXqwYHCITLPrG5tcKO2DPljelsG6vOBUefmDWCd4cmhyT1Vgda6wCzn5_sJprilHdHTEzT4_h0R4-ccrICNrI3ErRP0Nh-Hycggn9Cwox42WZFtAGOk0IrO4umn0cDR0HIsJ_DHSs-F0FL_c5wpMNzxtxWj6xttqUEzZk9EcXZbj0KJYz_SXDwPkw359h0fX2JLnGolOXw9Hwyzmu6X8DkLxKDLgP6mnfqfZO5DU5Ql6ma9qFZnU3c_d5Xh5GWydupTXa-Co9PMYf8K-RwcXO46J7bKCKUc9iSUpRonWkVuaNDm3hB9Lo7pmajmNgcoSBFcMw_j6fC_UCBwC_w";
+        given(authorizationService.authenticateOrRegisterUser(eq(LoginType.KAKAO),eq(fakeToken))).willReturn(Map.of("id","123415"));
+
+        mockMvc.perform(post("/api/v1/social-login")
+                .param("type", String.valueOf(LoginType.KAKAO))
+                .header("Authorization",fakeToken))
+                .andDo(print());
+
+    }
+
+}


### PR DESCRIPTION
## 개요
- 소셜로그인시 최초 동작시에 소셜 ID를 저장후 생성된 memberId를통해 JWT토큰을 생성해 추가 정보를 입력하도록 반환해줍니다.
- 로그인시에는 JWT토큰과 간단한 사용자의 정보를 담아 반환합니다.

Resolves: #3

## PR 유형
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).