### PR TITLE
운동 등록 및 S3 이미지 저장, AOP 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.15'
 	implementation 'com.auth0:java-jwt:4.4.0'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.15'
 	implementation 'com.auth0:java-jwt:4.4.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -56,7 +56,7 @@ public class ExerciseController {
     @Operation(summary = "커스텀 운동 등록", description = "사용자는 커스텀 운동을 등록가능하며 단일 사진만 등록 가능합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"회원가입 성공\",\"data\":{\"tokenInfo\":{\"memberId\":1}}}"))),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"저장 성공\"}"))),
             @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
             @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 값 입렵 검증", content = @Content(schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -68,8 +68,8 @@ public class ExerciseController {
             @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
     })
-    @PostMapping(value = "/save", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> saveExercise(@Valid @RequestPart(name = "customExerciseReqeust", required = false) CustomExerciseReqeust customExerciseReqeust, BindingResult result,
+    @PostMapping(value = "/save-exercise", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> saveExercise(@Valid @RequestPart(name = "customExerciseReqeust") CustomExerciseReqeust customExerciseReqeust, BindingResult result,
                                           @RequestPart(name ="file" , required = false) MultipartFile file,
                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long id = principalDetails.getMember().getId();

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import team9499.commitbody.domain.exercise.dto.CustomExerciseReqeust;
@@ -67,7 +69,7 @@ public class ExerciseController {
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
     })
     @PostMapping(value = "/save", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<?> saveExercise(@RequestPart(name = "customExerciseReqeust", required = false) CustomExerciseReqeust customExerciseReqeust,
+    public ResponseEntity<?> saveExercise(@Valid @RequestPart(name = "customExerciseReqeust", required = false) CustomExerciseReqeust customExerciseReqeust, BindingResult result,
                                           @RequestPart(name ="file" , required = false) MultipartFile file,
                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long id = principalDetails.getMember().getId();

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -19,6 +19,7 @@ import team9499.commitbody.domain.exercise.dto.SearchExerciseResponse;
 import team9499.commitbody.domain.exercise.event.ElasticSaveExerciseEvent;
 import team9499.commitbody.domain.exercise.service.ExerciseService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
 
 @RestController
@@ -50,6 +51,21 @@ public class ExerciseController {
     }
 
 
+    @Operation(summary = "커스텀 운동 등록", description = "사용자는 커스텀 운동을 등록가능하며 단일 사진만 등록 가능합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"회원가입 성공\",\"data\":{\"tokenInfo\":{\"memberId\":1}}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 값 입렵 검증", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"실패\",\"data\":{\"필드명\": \"오류 내용\"}}"))),
+            @ApiResponse(responseCode = "400_3", description = "BADREQUEST - 파일 용량 초과(5MB 이하만 저장가능)",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"저장 가능한 용량을 초과 했습니다.\"}"))),
+            @ApiResponse(responseCode = "400_4", description = "BADREQUEST - 불가능한 이미지 파일 저장시(jpeg, jpg, png, gif 저장가능)",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"올바른 이미지 형식이 아닙니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
+    })
     @PostMapping(value = "/save", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> saveExercise(@RequestPart(name = "customExerciseReqeust", required = false) CustomExerciseReqeust customExerciseReqeust,
                                           @RequestPart(name ="file" , required = false) MultipartFile file,

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/SchedulingController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/SchedulingController.java
@@ -16,11 +16,13 @@ public class SchedulingController {
 
     private final SchedulingService schedulingService;
 
+    @Hidden
     @PostMapping("/api/v1/scheduled")
     public void updateGifUrlSch(){
         schedulingService.updateGifUrl();
     }
 
+    @Hidden
     @PostMapping("/api/v1/scheduled/elastic")
     public void updateElData(){
         schedulingService.updateElData();

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/CustomExercise.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/CustomExercise.java
@@ -1,7 +1,10 @@
 package team9499.commitbody.domain.exercise.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.domain.exercise.domain.converter.ExerciseEquipmentConverter;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
@@ -9,6 +12,9 @@ import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
 
 @Data
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CustomExercise {
 
     @Id
@@ -30,4 +36,8 @@ public class CustomExercise {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
+    public CustomExercise save(String exerciseName,String gifUrl, ExerciseTarget exerciseTarget, ExerciseEquipment exerciseEquipment,Member member){
+        return CustomExercise.builder()
+                .customExName(exerciseName).customGifUrl(gifUrl).exerciseTarget(exerciseTarget).exerciseEquipment(exerciseEquipment).member(member).build();
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseDoc.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseDoc.java
@@ -47,4 +47,13 @@ public class ExerciseDoc {
     @Field(type = FieldType.Boolean,name = "favorites")             // 관심운동
     private Boolean favorites;
 
+
+    public ExerciseDoc customExercise(CustomExercise customExercise,String gifUrl){
+        return ExerciseDoc.builder()
+                .exerciseId(String.valueOf(customExercise.getId())).exerciseName(customExercise.getCustomExName()).gifUrl(gifUrl)
+                .exerciseType(null).exerciseEquipment(customExercise.getExerciseEquipment().getKoreanName()).memberId(String.valueOf(customExercise.getMember().getId()))
+                .source("custom").favorites(false).build();
+    }
+
+
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseMethod.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseMethod.java
@@ -1,4 +1,4 @@
-package team9499.commitbody.domain.exercise.domain.enums;
+package team9499.commitbody.domain.exercise.domain;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/enums/ExerciseEquipment.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/enums/ExerciseEquipment.java
@@ -1,5 +1,9 @@
 package team9499.commitbody.domain.exercise.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
 /*
 운동 장비
  */
@@ -32,5 +36,15 @@ public enum ExerciseEquipment {
             }
         }
         return null;
+    }
+
+    @JsonCreator
+    public static ExerciseEquipment fromEventStatus(String val) {
+        if (val ==null || val.equals("")){
+            return null;
+        }
+        return Arrays.stream(values())
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/enums/ExerciseTarget.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/enums/ExerciseTarget.java
@@ -1,7 +1,19 @@
 package team9499.commitbody.domain.exercise.domain.enums;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+
 public enum ExerciseTarget {
 
-    복근, 등, 가슴, 엉덩이, 대퇴사두근, 삼두, 이두, 어깨, 종아리, 햄스트링, 전완, 기타
+    복근, 등, 가슴, 엉덩이, 대퇴사두근, 삼두, 이두, 어깨, 종아리, 햄스트링, 전완, 기타;
 
+    @JsonCreator
+    public static ExerciseTarget fromEventStatus(String val) {
+        if (val ==null || val.equals("")){
+            return null;
+        }
+        return Arrays.stream(values())
+                .findFirst()
+                .orElse(null);
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseReqeust.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseReqeust.java
@@ -1,20 +1,26 @@
 package team9499.commitbody.domain.exercise.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
+import team9499.commitbody.global.annotations.ValidEnum;
 
 @Schema(name = "커스텀 운동 등록 Request")
 @Data
 public class CustomExerciseReqeust {
 
     @Schema(description = "커스텀 운동명")
+    @NotBlank(message = "운동명을 입력해주세요")
     private String exerciseName;
 
     @Schema(description = "운동 장비")
+    @ValidEnum(message = "운동 장비를 입력해주세요" ,enumClass = ExerciseEquipment.class)
     private ExerciseEquipment exerciseEquipment;
 
     @Schema(description = "운동 부위")
+    @ValidEnum(message = "운동 부위를 입력해주세요",enumClass = ExerciseTarget.class)
     private ExerciseTarget exerciseTarget;
+
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseReqeust.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseReqeust.java
@@ -1,0 +1,15 @@
+package team9499.commitbody.domain.exercise.dto;
+
+import lombok.Data;
+import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
+import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
+
+@Data
+public class CustomExerciseReqeust {
+
+    private String exerciseName;
+
+    private ExerciseEquipment exerciseEquipment;
+
+    private ExerciseTarget exerciseTarget;
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseReqeust.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseReqeust.java
@@ -1,15 +1,20 @@
 package team9499.commitbody.domain.exercise.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
 
+@Schema(name = "커스텀 운동 등록 Request")
 @Data
 public class CustomExerciseReqeust {
 
+    @Schema(description = "커스텀 운동명")
     private String exerciseName;
 
+    @Schema(description = "운동 장비")
     private ExerciseEquipment exerciseEquipment;
 
+    @Schema(description = "운동 부위")
     private ExerciseTarget exerciseTarget;
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ElasticSaveExerciseEvent.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ElasticSaveExerciseEvent.java
@@ -1,0 +1,14 @@
+package team9499.commitbody.domain.exercise.event;
+
+
+import lombok.Getter;
+
+@Getter
+public class ElasticSaveExerciseEvent {
+
+    private Long customExerciseId;
+
+    public ElasticSaveExerciseEvent(Long customExerciseId) {
+        this.customExerciseId = customExerciseId;
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
@@ -1,0 +1,18 @@
+package team9499.commitbody.domain.exercise.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import team9499.commitbody.domain.exercise.service.ElasticExerciseService;
+
+@Component
+@RequiredArgsConstructor
+public class ExerciseHandler {
+
+    private final ElasticExerciseService exerciseService;
+
+    @EventListener
+    public void ElSaveExercise(ElasticSaveExerciseEvent elasticSaveExerciseEvent){
+       exerciseService.saveExercise(elasticSaveExerciseEvent.getCustomExerciseId());
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/repository/ExerciseMethodRepository.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/repository/ExerciseMethodRepository.java
@@ -2,7 +2,7 @@ package team9499.commitbody.domain.exercise.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-import team9499.commitbody.domain.exercise.domain.enums.ExerciseMethod;
+import team9499.commitbody.domain.exercise.domain.ExerciseMethod;
 
 @Repository
 public interface ExerciseMethodRepository extends JpaRepository<ExerciseMethod, Long> {

--- a/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
@@ -1,0 +1,6 @@
+package team9499.commitbody.domain.exercise.service;
+
+public interface ElasticExerciseService {
+
+    void saveExercise(Long customExerciseId);
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/service/ExerciseService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/ExerciseService.java
@@ -1,8 +1,13 @@
 package team9499.commitbody.domain.exercise.service;
 
+import org.springframework.web.multipart.MultipartFile;
+import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
+import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
 import team9499.commitbody.domain.exercise.dto.SearchExerciseResponse;
 
 public interface ExerciseService {
 
     SearchExerciseResponse searchExercise(String name, String target,String equipment, Integer from, Integer size, Boolean like, String memberId);
+
+    Long saveCustomExercise(String exerciseName, ExerciseTarget exerciseTarget, ExerciseEquipment exerciseEquipment, Long memberId, MultipartFile file);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
@@ -1,0 +1,38 @@
+package team9499.commitbody.domain.exercise.service.Impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9499.commitbody.domain.exercise.domain.CustomExercise;
+import team9499.commitbody.domain.exercise.domain.ExerciseDoc;
+import team9499.commitbody.domain.exercise.repository.CustomExerciseRepository;
+import team9499.commitbody.domain.exercise.repository.ExerciseElsRepository;
+import team9499.commitbody.domain.exercise.service.ElasticExerciseService;
+
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ElasticExerciseServiceImpl implements ElasticExerciseService {
+
+    private final CustomExerciseRepository customExerciseRepository;
+    private final ExerciseElsRepository exerciseElsRepository;
+
+    @Value("${cloud.aws.cdn.url}")
+    private String cdnUrl;
+
+    /**
+     * 커스텀 운동 저장
+     */
+    @Override
+    public void saveExercise(Long customExerciseId) {
+        CustomExercise customExercise = customExerciseRepository.findById(customExerciseId).orElse(null);
+        ExerciseDoc exerciseDoc = new ExerciseDoc().customExercise(customExercise,getCustomGifUrl(customExercise));
+        exerciseElsRepository.save(exerciseDoc);
+    }
+
+    private String getCustomGifUrl(CustomExercise customExercise) {
+        return customExercise.getCustomGifUrl() ==null ? "등록된 이미지 파일이 없습니다." : cdnUrl+customExercise.getCustomGifUrl();
+    }
+}

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionAdvice.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionAdvice.java
@@ -3,6 +3,7 @@ package team9499.commitbody.global.Exception;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import team9499.commitbody.global.payload.ErrorResponse;
 
 @RestControllerAdvice
@@ -34,5 +35,11 @@ public class ExceptionAdvice {
         ErrorResponse er = new ErrorResponse(false, e.getMessage());
         e.printStackTrace();
         return ResponseEntity.status(e.getExceptionStatus()).body(er);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<ErrorResponse> MaxUploadSizeExceededException(MaxUploadSizeExceededException e){
+        ErrorResponse er = new ErrorResponse(false,"저장 가능한 용량을 초과 했습니다.");
+        return ResponseEntity.status(400).body(er);
     }
 }

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionType.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionType.java
@@ -10,7 +10,8 @@ public enum ExceptionType {
     TOKEN_EXPIRED("만료된 토큰 입니다."),
     LOGIN_REQUIRED("접근하려는 페이지에 접근하려면 로그인해야 합니다."),
     ACCESS_DENIED("이 리소스에 접근할 권한이 없습니다."),
-    DUPLICATE_NICKNAME("중복된 닉네임 입니다.");
+    DUPLICATE_NICKNAME("중복된 닉네임 입니다."),
+    INVALID_IMAGE_FORMAT("올바른 이미지 형식이 아닙니다.");
 
 
     private final String message;

--- a/src/main/java/team9499/commitbody/global/annotations/EnumValidator.java
+++ b/src/main/java/team9499/commitbody/global/annotations/EnumValidator.java
@@ -1,0 +1,29 @@
+package team9499.commitbody.global;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class EnumValidator implements ConstraintValidator<ValidEnum,Enum> {
+
+    private ValidEnum validEnum;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+       this.validEnum = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        Object[] enumValues = this.validEnum.enumClass().getEnumConstants();
+        if (enumValues!=null){
+            for (Object enumVale : enumValues){
+                if (value == enumVale){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/team9499/commitbody/global/annotations/EnumValidator.java
+++ b/src/main/java/team9499/commitbody/global/annotations/EnumValidator.java
@@ -1,4 +1,4 @@
-package team9499.commitbody.global;
+package team9499.commitbody.global.annotations;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/src/main/java/team9499/commitbody/global/annotations/ValidEnum.java
+++ b/src/main/java/team9499/commitbody/global/annotations/ValidEnum.java
@@ -1,0 +1,21 @@
+package team9499.commitbody.global;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.METHOD,ElementType.FIELD,ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+
+    String message() default "Invalid value";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/src/main/java/team9499/commitbody/global/annotations/ValidEnum.java
+++ b/src/main/java/team9499/commitbody/global/annotations/ValidEnum.java
@@ -1,8 +1,7 @@
-package team9499.commitbody.global;
+package team9499.commitbody.global.annotations;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
-import org.hibernate.validator.internal.constraintvalidators.bv.EmailValidator;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/team9499/commitbody/global/aop/AspectAdvice.java
+++ b/src/main/java/team9499/commitbody/global/aop/AspectAdvice.java
@@ -1,2 +1,60 @@
-package team9499.commitbody.global.aop;public class AspectAdvice {
+package team9499.commitbody.global.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import team9499.commitbody.global.payload.ErrorResponse;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@Aspect
+@Component("aspectAdvice")
+public class AspectAdvice {
+
+    @Around("team9499.commitbody.global.aop.Pointcuts.executionTime()")
+    public Object executionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+        String methodName = joinPoint.getSignature().toLongString();
+
+        try {
+            log.info("start method: {}", methodName);
+            Object result = joinPoint.proceed();
+
+            long executionTime = System.currentTimeMillis() - start;
+            log.info("end method:{} time in {} ms", methodName, executionTime);
+
+            return result;
+        } catch (Throwable e) {
+            log.error("Exception in method {}: {}", methodName, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Around("team9499.commitbody.global.aop.Pointcuts.validResponse()")
+    public Object validResponse(ProceedingJoinPoint joinPoint) throws Throwable {
+        Object[] args = joinPoint.getArgs();
+
+        for (Object arg : args){
+            if (arg instanceof BindingResult){
+                BindingResult result = (BindingResult) arg;
+                if (result.hasErrors()){
+                    Map<String,String> errorMap = new LinkedHashMap<>();
+                    for(FieldError error : result.getFieldErrors()){
+                        errorMap.put(error.getField(),error.getDefaultMessage());
+                    }
+                    return ResponseEntity.status(BAD_REQUEST).body(new ErrorResponse<>(false, "실패", errorMap));
+                }
+            }
+        }
+        return joinPoint.proceed();
+    }
 }

--- a/src/main/java/team9499/commitbody/global/aop/AspectAdvice.java
+++ b/src/main/java/team9499/commitbody/global/aop/AspectAdvice.java
@@ -1,0 +1,2 @@
+package team9499.commitbody.global.aop;public class AspectAdvice {
+}

--- a/src/main/java/team9499/commitbody/global/aop/Pointcuts.java
+++ b/src/main/java/team9499/commitbody/global/aop/Pointcuts.java
@@ -1,0 +1,2 @@
+package team9499.commitbody.global.aop;public class Pointcuts {
+}

--- a/src/main/java/team9499/commitbody/global/aop/Pointcuts.java
+++ b/src/main/java/team9499/commitbody/global/aop/Pointcuts.java
@@ -1,2 +1,15 @@
-package team9499.commitbody.global.aop;public class Pointcuts {
+package team9499.commitbody.global.aop;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+@Aspect
+public class Pointcuts {
+
+    @Pointcut("execution(* *..*Controller.*(..))")
+    void executionTime(){}
+
+    @Pointcut("execution(* *..*Controller.*(..))")
+    void validResponse(){}
+
 }

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.Member.domain.LoginType;
 import team9499.commitbody.global.authorization.dto.AdditionalInfoReqeust;
@@ -23,10 +22,8 @@ import team9499.commitbody.global.authorization.service.AuthorizationService;
 import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.springframework.http.HttpStatus.*;
 
 @Tag(name = "인증 인가",description = "인증 인가관련된 API")
 @Slf4j
@@ -69,9 +66,6 @@ public class AuthorizationController {
     })
     @PostMapping("/additional-info")
     public ResponseEntity<?> additionalInfo(@Valid @RequestBody AdditionalInfoReqeust additionalInfoReqeust, BindingResult result,HttpServletRequest request){
-        ResponseEntity<ErrorResponse<Map<String, String>>> errorResponse = getResponseResponseEntity(result);
-        if (errorResponse != null) return errorResponse;
-
         String jwtToken = getJwtToken(request);
 
         TokenUserInfoResponse tokenUserInfoResponse = authorizationService.additionalInfoSave(
@@ -96,10 +90,6 @@ public class AuthorizationController {
     })
     @PostMapping("/register-nickname")
     public ResponseEntity<?> registerNickname(@Valid @RequestBody RegisterNicknameRequest registerNicknameRequest, BindingResult result){
-        ResponseEntity<ErrorResponse<Map<String, String>>> errorResponse = getResponseResponseEntity(result);
-        if (errorResponse != null) return errorResponse;
-
-
         authorizationService.registerNickname(registerNicknameRequest.getNickname());
         return ResponseEntity.ok(new SuccessResponse<>(true,"사용 가능"));
     }
@@ -107,15 +97,5 @@ public class AuthorizationController {
     private static String getJwtToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
         return authorization.replace("Bearer ", "");
-    }
-    private static ResponseEntity<ErrorResponse<Map<String, String>>> getResponseResponseEntity(BindingResult result) {
-        if (result.hasErrors()){
-            Map<String,String> errorMap = new LinkedHashMap<>();
-            for(FieldError error : result.getFieldErrors()){
-                errorMap.put(error.getField(),error.getDefaultMessage());
-            }
-            return ResponseEntity.status(BAD_REQUEST).body(new ErrorResponse<>(false, "실패", errorMap));
-        }
-        return null;
     }
 }

--- a/src/main/java/team9499/commitbody/global/aws/s3/S3Service.java
+++ b/src/main/java/team9499/commitbody/global/aws/s3/S3Service.java
@@ -1,0 +1,9 @@
+package team9499.commitbody.global.aws.s3;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Service {
+    String uploadImage(MultipartFile file);
+    String updateImage(MultipartFile file, String previousFileName);
+    void deleteImage(String fileName);
+}

--- a/src/main/java/team9499/commitbody/global/aws/s3/S3ServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/aws/s3/S3ServiceImpl.java
@@ -1,0 +1,96 @@
+package team9499.commitbody.global.aws.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.InvalidUsageException;
+import team9499.commitbody.global.Exception.ServerException;
+
+import java.io.InputStream;
+import java.util.Set;
+import java.util.UUID;
+
+import static team9499.commitbody.global.Exception.ExceptionType.*;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class S3ServiceImpl implements S3Service{
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket.image}")
+    private String bucketImage;
+
+    /**
+     * 파일 업로드
+     * 저장된 파일명을 반환한다.
+     */
+    @Override
+    public String uploadImage(MultipartFile file) {
+        String storedFileName =null;
+        if (file!=null) {
+            String originalFilename = file.getOriginalFilename();
+
+            storedFileName = createUUID(originalFilename);
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+
+            try {
+                InputStream inputStream = file.getInputStream();
+                amazonS3.putObject(new PutObjectRequest(bucketImage, storedFileName, inputStream, objectMetadata));
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw new ServerException(ExceptionStatus.SERVER_ERROR, SERVER_ERROR);
+            }
+        }
+
+        return storedFileName;
+    }
+
+    /**
+     * 파일을 업데이트한다. 이전파일을 삭제후 새로운 파일을 저장
+     */
+    @Override
+    public String updateImage(MultipartFile file, String previousFileName) {
+        deleteImage(previousFileName);
+        return uploadImage(file);
+    }
+
+    /**
+     * 파일 삭제
+     */
+    @Override
+    public void deleteImage(String fileName) {
+        try {
+            amazonS3.deleteObject(bucketImage,fileName);
+        }catch (Exception e){
+            log.error("이미지 삭제중 오류 발생");
+            throw new ServerException(ExceptionStatus.SERVER_ERROR,SERVER_ERROR);
+        }
+    }
+
+
+
+
+    private String createUUID(String fileName){
+        int indexOf = fileName.lastIndexOf(".");
+        String extension = fileName.substring(indexOf + 1).toLowerCase();
+
+        Set<String> allowedExtensions = Set.of("jpeg", "jpg", "png","gif");
+        if (!allowedExtensions.contains(extension)){
+            throw new InvalidUsageException(ExceptionStatus.BAD_REQUEST, INVALID_IMAGE_FORMAT);
+        }
+        String uuid = UUID.randomUUID().toString();
+        return uuid+"."+extension;
+    }
+}

--- a/src/main/java/team9499/commitbody/global/config/S3Config.java
+++ b/src/main/java/team9499/commitbody/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package team9499.commitbody.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 AmazonS3Client(){
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/team9499/commitbody/global/converter/MultipartJackson2HttpMessageConverter.java
+++ b/src/main/java/team9499/commitbody/global/converter/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,30 @@
+package team9499.commitbody.global.converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+    protected MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+
+}

--- a/src/main/java/team9499/commitbody/global/utils/JwtUtils.java
+++ b/src/main/java/team9499/commitbody/global/utils/JwtUtils.java
@@ -56,7 +56,7 @@ public class JwtUtils {
      * RefreshToken 발급을 당당하는 메서드
      */
     public  String generateRefreshToken(MemberDto memberDto) {
-        LocalDateTime now = LocalDateTime.now().plusHours(REFRESH_TOKEN_EXPIRED);
+        LocalDateTime now = LocalDateTime.now().plusMonths(REFRESH_TOKEN_EXPIRED);
         return creatToken(memberDto, Timestamp.valueOf(now));
     }
 


### PR DESCRIPTION
## 개요
### ※ 커스텀 운동 등록 구현
사용자 정의 운동 등록 기능을 추가했으며, 엘라스틱과 데이터의 정합성을 위해 이벤트를 통해 저장시 엘라스틱에도 저장되도록 구현했습니다.

### ※ 이미지 파일 S3 저장
이미지 파일을 로컬 서버에 저장하는 대신 AWS S3에 저장하도록 구현하여, 스토리지 관리와 확장성을 향상시켰습니다.

### ※ 중복된 @Valid 검증 코드 처리:
중복된 @Valid 검증 코드가 발생하는 문제를 해결하기 위해 AOP(Aspect-Oriented Programming)를 사용하여 검증 로직의 관심사를 분리했습니다. 이로 인해 코드의 유지보수성과 재사용성이 개선되었습니다.

Resolves: #11,  #12

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).