### PR TITLE
AccessToken reissuance Implements

### DIFF
--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -14,6 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.Exception.NoSuchException;
 import team9499.commitbody.global.authorization.dto.AdditionalInfoReqeust;
 import team9499.commitbody.global.authorization.dto.JoinLoginRequest;
 import team9499.commitbody.global.authorization.dto.RegisterNicknameRequest;
@@ -112,6 +115,7 @@ public class AuthorizationController {
 
     private static String getJwtToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
+        if (authorization==null) throw new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA);
         return authorization.replace("Bearer ", "");
     }
 }

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -91,6 +91,18 @@ public class AuthorizationController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"사용 가능"));
     }
 
+
+    @Operation(summary = "엑세스 토큰 재발급", description = "엑세스 토큰 만료시 RefreshToken을 통해 AccessToken을 재발급 받습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"재발급 성공\",\"data\":{\"accessToken\":\"accessToken_value\"}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401_2", description = "UNAUTHORIZED - 토큰 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"만료된 토큰 입니다.\"}"))),
+            @ApiResponse(responseCode = "401_1", description = "UNAUTHORIZED - 미존재 토큰 사용", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
+    })
     @PostMapping("/auth-refresh")
     public ResponseEntity<?> refreshAccessToken(HttpServletRequest request){
         String refreshToken = getJwtToken(request);

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -101,6 +101,8 @@ public class AuthorizationController {
                     examples = @ExampleObject(value = "{\"success\":true,\"message\":\"재발급 성공\",\"data\":{\"accessToken\":\"accessToken_value\"}}"))),
             @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - Authorization Null",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"해당 정보를 찾을수 없습니다.\"}"))),
             @ApiResponse(responseCode = "401_2", description = "UNAUTHORIZED - 토큰 만료", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"만료된 토큰 입니다.\"}"))),
             @ApiResponse(responseCode = "401_1", description = "UNAUTHORIZED - 미존재 토큰 사용", content = @Content(schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -91,6 +91,13 @@ public class AuthorizationController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"사용 가능"));
     }
 
+    @PostMapping("/auth-refresh")
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request){
+        String refreshToken = getJwtToken(request);
+        Map<String, String> map = authorizationService.refreshAccessToken(refreshToken);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"재발급 성공",map));
+    }
+
     private static String getJwtToken(HttpServletRequest request) {
         String authorization = request.getHeader("Authorization");
         return authorization.replace("Bearer ", "");

--- a/src/main/java/team9499/commitbody/global/authorization/service/AuthorizationService.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/AuthorizationService.java
@@ -14,4 +14,6 @@ public interface AuthorizationService {
     TokenUserInfoResponse additionalInfoSave(String nickName, Gender gender, LocalDate birthday, String height, String weight, Float boneMineralDensity, Float bodyFatPercentage, String jwtToken);
 
     void registerNickname(String nickname);
+
+    Map<String,String> refreshAccessToken(String refreshToken);
 }

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
@@ -107,6 +107,18 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         }
     }
 
+    /**
+     * 리프레쉬 토큰을 통한 엑시스토큰 재발급
+     */
+    @Override
+    public Map<String,String> refreshAccessToken(String refreshToken) {
+        String verifyMemberId = jwtUtils.accessTokenValid(refreshToken);
+        memberRepository.findById(Long.valueOf(verifyMemberId)).orElseThrow(() -> new NoSuchException(BAD_REQUEST, No_SUCH_MEMBER));
+
+        String newAccessToken = jwtUtils.generateAccessToken(MemberDto.builder().memberId(Long.valueOf(verifyMemberId)).build());
+        return Map.of("accessToken",newAccessToken);
+    }
+
     /*
     레디스의 정보가 서버의 문제로 인해 삭제될수있기때문에 MySQL에 리프레쉬 토큰을 저장
      */

--- a/src/main/java/team9499/commitbody/global/config/SecurityConfig.java
+++ b/src/main/java/team9499/commitbody/global/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(authorizeRequests ->
                 authorizeRequests
                         .requestMatchers("/api/v1/auth","/actuator/**","/api/v1/swagger-ui/**", "/v3/api-docs/**", "/api/v1/swagger-ui.html","/api-docs/**",
-                                "/api/v1/additional-info","/api/v1/scheduled/**"
+                                "/api/v1/additional-info","/api/v1/scheduled/**","/api/v1/auth-refresh"
                                 ).permitAll()
                         .requestMatchers("/api/v1/**").hasAnyRole("USER"));
         return http.build();

--- a/src/main/java/team9499/commitbody/global/config/SwaggerConfig.java
+++ b/src/main/java/team9499/commitbody/global/config/SwaggerConfig.java
@@ -21,10 +21,10 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openApi(){
 
-        String socialToken ="SocialToken";
+        String jwtToken ="JWT-TOKEN";
 
         SecurityRequirement securityRequirement = new SecurityRequirement()
-                .addList(socialToken);
+                .addList(jwtToken);
 
         SecurityScheme socialTokenSc = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
@@ -34,7 +34,7 @@ public class SwaggerConfig {
                 .name(HttpHeaders.AUTHORIZATION);
 
         Components components = new Components()
-                .addSecuritySchemes(socialToken, socialTokenSc);
+                .addSecuritySchemes(jwtToken, socialTokenSc);
 
         return new OpenAPI()
                 .addSecurityItem(securityRequirement)

--- a/src/main/java/team9499/commitbody/global/redis/RedisService.java
+++ b/src/main/java/team9499/commitbody/global/redis/RedisService.java
@@ -12,7 +12,7 @@ public interface RedisService {
     void setValues(String key, String value, Duration duration);
     String getValue(String key);
     void deleteValue(String key);
-    void setMember(Member member);
+    void setMember(Member member,Duration duration);
     Optional<Member> getMemberDto(String key);
 
     boolean nicknameLock(String key, String value,Duration duration);

--- a/src/main/java/team9499/commitbody/global/redis/RedisServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/redis/RedisServiceImpl.java
@@ -44,8 +44,8 @@ public class RedisServiceImpl implements RedisService{
     }
 
     @Override
-    public void setMember(Member member) {
-        redisTemplate.opsForValue().set(MEMBER_ID+member.getId(),member);
+    public void setMember(Member member,Duration duration) {
+        redisTemplate.opsForValue().set(MEMBER_ID+member.getId(),member,duration);
     }
 
     @Override

--- a/src/main/java/team9499/commitbody/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/team9499/commitbody/global/security/filter/JwtAuthenticationFilter.java
@@ -20,6 +20,7 @@ import team9499.commitbody.global.redis.RedisService;
 import team9499.commitbody.global.utils.JwtUtils;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Optional;
 
 @Slf4j
@@ -45,7 +46,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Optional<Member> optionalMember = redisService.getMemberDto(accessTokenValid);
         if (optionalMember.isEmpty()){
             Member member = memberRepository.findById(Long.parseLong(accessTokenValid)).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.No_SUCH_MEMBER));
-            redisService.setMember(member);
+            redisService.setMember(member, Duration.ofHours(2));
             optionalMember = Optional.of(member);
         }
 


### PR DESCRIPTION
## 개요
- AccessToken 만료시 RefreshToken을통한 AccessToken을 재발급 받도록 
- JwtAuthenticationFilter에서 Reids의 사용자 정보를 저장할때 메모리를 최적화 하기위해 일정 시간동안만 저장 리팩토링
- Swagger Authentication 헤더 명칭 변경

Resolves: #19 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).