### PR TITLE
커스텀 운동 삭제 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -19,12 +19,14 @@ import org.springframework.web.multipart.MultipartFile;
 import team9499.commitbody.domain.exercise.dto.CustomExerciseReqeust;
 import team9499.commitbody.domain.exercise.dto.CustomUpdateExerciseReqeust;
 import team9499.commitbody.domain.exercise.dto.SearchExerciseResponse;
+import team9499.commitbody.domain.exercise.event.ElasticDeleteExerciseEvent;
 import team9499.commitbody.domain.exercise.event.ElasticSaveExerciseEvent;
 import team9499.commitbody.domain.exercise.event.ElasticUpdateExerciseEvent;
 import team9499.commitbody.domain.exercise.service.ExerciseService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
 import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
+
 
 @RestController
 @Tag(name = "운동",description = "운동관련 API")
@@ -110,5 +112,15 @@ public class ExerciseController {
 
         return ResponseEntity.ok(new SuccessResponse<>(true,"업데이트 성공"));
 
+    }
+
+    @DeleteMapping( "/delete-exercise")
+    public ResponseEntity<?> deleteExercise(@RequestParam("id") Long customExerciseId,
+                                            @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = principalDetails.getMember().getId();
+        exerciseService.deleteCustomExercise(customExerciseId,memberId);
+        eventPublisher.publishEvent(new ElasticDeleteExerciseEvent(customExerciseId));
+
+        return ResponseEntity.ok(new SuccessResponse<>(true,"업데이트 성공"));
     }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ElasticDeleteExerciseEvent.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ElasticDeleteExerciseEvent.java
@@ -1,0 +1,13 @@
+package team9499.commitbody.domain.exercise.event;
+
+import lombok.Data;
+
+@Data
+public class ElasticDeleteExerciseEvent {
+
+    private Long customExerciseId;
+
+    public ElasticDeleteExerciseEvent(Long customExerciseId) {
+        this.customExerciseId = customExerciseId;
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
@@ -20,4 +20,9 @@ public class ExerciseHandler {
     public void ElUpdateExercise(ElasticUpdateExerciseEvent elasticUpdateExerciseEvent){
         exerciseService.updateExercise(elasticUpdateExerciseEvent.getCustomExerciseId());
     }
+
+    @EventListener
+    public void ElDeleteExercise(ElasticDeleteExerciseEvent elasticDeleteExerciseEvent){
+        exerciseService.deleteExercise(elasticDeleteExerciseEvent.getCustomExerciseId());
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/repository/CustomExerciseRepository.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/repository/CustomExerciseRepository.java
@@ -4,6 +4,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import team9499.commitbody.domain.exercise.domain.CustomExercise;
 
+import java.util.Optional;
+
 @Repository
 public interface CustomExerciseRepository extends JpaRepository<CustomExercise, Long> {
+
+    Optional<CustomExercise> findByIdAndAndMemberId(Long customExerciseId,Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
@@ -5,4 +5,6 @@ public interface ElasticExerciseService {
     void saveExercise(Long customExerciseId);
 
     void updateExercise(Long customExerciseId);
+
+    void deleteExercise(Long customExerciseId);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/ExerciseService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/ExerciseService.java
@@ -12,4 +12,6 @@ public interface ExerciseService {
     Long saveCustomExercise(String exerciseName, ExerciseTarget exerciseTarget, ExerciseEquipment exerciseEquipment, Long memberId, MultipartFile file);
 
     Long updateCustomExercise(String exerciseName, ExerciseTarget exerciseTarget, ExerciseEquipment exerciseEquipment, Long memberId, Long customExerciseId,MultipartFile file);
+
+    void deleteCustomExercise(Long customExerciseId,Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.domain.exercise.service.Impl;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.DeleteRequest;
 import co.elastic.clients.elasticsearch.core.UpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
     @Value("${cloud.aws.cdn.url}")
     private String cdnUrl;
 
+    private final String INDEX = "exercise_index";
     /**
      * 커스텀 운동 저장
      */
@@ -54,10 +56,23 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
         updateBody.put("doc",doc);
 
         try {
-            UpdateRequest<Object, Object> updateRequest = UpdateRequest.of(u -> u.index("exercise_index").id(String.valueOf(customExercise.getId())).doc(doc));
+            UpdateRequest<Object, Object> updateRequest = UpdateRequest.of(u -> u.index(INDEX).id(String.valueOf(customExercise.getId())).doc(doc));
             elasticsearchClient.update(updateRequest, Map.class);
         }catch (Exception e){
             log.error("엘라스틱 업데이트시 문제 발생");
+        }
+    }
+
+    /**
+     * 엘라스틱 커스텀 운동 삭제 메서드
+     */
+    @Override
+    public void deleteExercise(Long customExerciseId) {
+        DeleteRequest deleteRequest = DeleteRequest.of(u -> u.index(INDEX).id(String.valueOf(customExerciseId)));
+        try {
+            elasticsearchClient.delete(deleteRequest);
+        }catch (Exception e){
+            log.error("엘라스틱 삭제중 오류 발생");
         }
     }
 

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ExerciseServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ExerciseServiceImpl.java
@@ -150,10 +150,19 @@ public class ExerciseServiceImpl implements ExerciseService {
      */
     @Override
     public Long updateCustomExercise(String exerciseName, ExerciseTarget exerciseTarget, ExerciseEquipment exerciseEquipment, Long memberId, Long customExerciseId, MultipartFile file) {
-        CustomExercise customExercise = customExerciseRepository.findById(customExerciseId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+        CustomExercise customExercise = getCustomExercise(customExerciseId,memberId);
         String updateImage = s3Service.updateImage(file, customExercise.getCustomGifUrl());
         customExercise.update(exerciseName,exerciseTarget,exerciseEquipment,updateImage);
         return customExercise.getId();
+    }
+
+    /**
+     * DB 커스텀 운동 삭제 메서드
+     */
+    @Override
+    public void deleteCustomExercise(Long customExerciseId, Long memberId) {
+        CustomExercise customExercise = getCustomExercise(customExerciseId,memberId);
+        customExerciseRepository.delete(customExercise);
     }
 
 
@@ -165,6 +174,11 @@ public class ExerciseServiceImpl implements ExerciseService {
             optionalMember = Optional.of(member);
         }
         return optionalMember;
+    }
+
+    private CustomExercise getCustomExercise(Long customExerciseId, Long memberId) {
+        CustomExercise customExercise = customExerciseRepository.findByIdAndAndMemberId(customExerciseId,memberId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+        return customExercise;
     }
 
 }


### PR DESCRIPTION
## 개요
- 작성만 등록한 커스텀 운동을 삭제할수 있습니다.
- 커스텀운동 삭제시 엘라스틱과 정합성을위해 Event를 통해 삭제되도록 했습니다.

Resolves: #21

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).