### PR TITLE
엘라스틱 검색, 운동 삭제 ,수정 , 등록 버그 해결

### DIFF
--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -108,7 +108,7 @@ public class ExerciseController {
         Long id = principalDetails.getMember().getId();
         Long customExerciseId = exerciseService.updateCustomExercise(customUpdateExerciseReqeust.getExerciseName(), customUpdateExerciseReqeust.getExerciseTarget(),
                 customUpdateExerciseReqeust.getExerciseEquipment(), id, customUpdateExerciseReqeust.getCustomExerciseId(),file);
-        eventPublisher.publishEvent(new ElasticUpdateExerciseEvent(customExerciseId));
+        eventPublisher.publishEvent(new ElasticUpdateExerciseEvent(customExerciseId,customUpdateExerciseReqeust.getSource()));
 
         return ResponseEntity.ok(new SuccessResponse<>(true,"업데이트 성공"));
 
@@ -117,7 +117,7 @@ public class ExerciseController {
     @Operation(summary = "커스텀 운동 삭제", description = "등록한 사용자만 커스텀 운동을 삭제 가능합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"업데이트 성공\"}"))),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"삭제 성공\"}"))),
             @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
             @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 커스텀 운동 미존재", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
@@ -132,6 +132,6 @@ public class ExerciseController {
         exerciseService.deleteCustomExercise(customExerciseId,memberId);
         eventPublisher.publishEvent(new ElasticDeleteExerciseEvent(customExerciseId));
 
-        return ResponseEntity.ok(new SuccessResponse<>(true,"업데이트 성공"));
+        return ResponseEntity.ok(new SuccessResponse<>(true,"삭제 성공"));
     }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseDoc.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseDoc.java
@@ -21,7 +21,10 @@ import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
 public class ExerciseDoc {
 
     @Id
-    private String exerciseId;                              // 운동 id
+    private String id;
+
+    @Field(type = FieldType.Long, name = "exerciseId")
+    private Long exerciseId;                              // 운동 id
 
     @Field(type = FieldType.Text, name = "exerciseName")        // 운동명
     private String exerciseName;
@@ -50,7 +53,8 @@ public class ExerciseDoc {
 
     public ExerciseDoc customExercise(CustomExercise customExercise,String gifUrl){
         return ExerciseDoc.builder()
-                .exerciseId(String.valueOf(customExercise.getId())).exerciseName(customExercise.getCustomExName()).gifUrl(gifUrl)
+                .id("custom_"+customExercise.getId())
+                .exerciseId(customExercise.getId()).exerciseName(customExercise.getCustomExName()).gifUrl(gifUrl)
                 .exerciseType(null).exerciseEquipment(customExercise.getExerciseEquipment().getKoreanName()).memberId(String.valueOf(customExercise.getMember().getId()))
                 .source("custom").favorites(false).build();
     }

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/CustomUpdateExerciseReqeust.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/CustomUpdateExerciseReqeust.java
@@ -15,7 +15,7 @@ public class CustomUpdateExerciseReqeust {
     
     @Schema(description = "커스텀 운동명")
     @NotBlank(message = "운동명을 입력해주세요")
-    private String exerciseName;
+        private String exerciseName;
 
     @Schema(description = "운동 장비")
     @ValidEnum(message = "운동 장비를 입력해주세요" ,enumClass = ExerciseEquipment.class)
@@ -24,5 +24,9 @@ public class CustomUpdateExerciseReqeust {
     @Schema(description = "운동 부위")
     @ValidEnum(message = "운동 부위를 입력해주세요",enumClass = ExerciseTarget.class)
     private ExerciseTarget exerciseTarget;
+
+    @Schema(description = "운동 등록타입 전송시 ' custom_ / default_ ' 보냅니다.")
+    @NotBlank(message = "운동 등록 타입을 선택해주세요")
+    private String source;
 
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/SearchExerciseResponse.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/SearchExerciseResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,5 +15,5 @@ public class SearchExerciseResponse {
 
     private Long totalCount;
 
-    private List<Map<String, Object>> exercise;
+    private   List<LinkedHashMap<String,Object>> exercise;
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ElasticUpdateExerciseEvent.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ElasticUpdateExerciseEvent.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 public class ElasticUpdateExerciseEvent {
 
     private Long customExerciseId;
+    private String source;
 
-    public ElasticUpdateExerciseEvent(Long customExerciseId) {
+    public ElasticUpdateExerciseEvent(Long customExerciseId,String source) {
         this.customExerciseId = customExerciseId;
+        this.source = source;
     }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
@@ -18,7 +18,7 @@ public class ExerciseHandler {
 
     @EventListener
     public void ElUpdateExercise(ElasticUpdateExerciseEvent elasticUpdateExerciseEvent){
-        exerciseService.updateExercise(elasticUpdateExerciseEvent.getCustomExerciseId());
+        exerciseService.updateExercise(elasticUpdateExerciseEvent.getCustomExerciseId(),elasticUpdateExerciseEvent.getSource());
     }
 
     @EventListener

--- a/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
@@ -4,7 +4,7 @@ public interface ElasticExerciseService {
 
     void saveExercise(Long customExerciseId);
 
-    void updateExercise(Long customExerciseId);
+    void updateExercise(Long customExerciseId,String source);
 
     void deleteExercise(Long customExerciseId);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
@@ -32,6 +32,7 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
     private String cdnUrl;
 
     private final String INDEX = "exercise_index";
+
     /**
      * 커스텀 운동 저장
      */
@@ -43,7 +44,7 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
     }
 
     @Override
-    public void updateExercise(Long customExerciseId) {
+    public void updateExercise(Long customExerciseId,String source) {
         CustomExercise customExercise = getCustomExercise(customExerciseId);
 
         Map<String,String> doc = new HashMap<>();
@@ -56,7 +57,7 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
         updateBody.put("doc",doc);
 
         try {
-            UpdateRequest<Object, Object> updateRequest = UpdateRequest.of(u -> u.index(INDEX).id(String.valueOf(customExercise.getId())).doc(doc));
+            UpdateRequest<Object, Object> updateRequest = UpdateRequest.of(u -> u.index(INDEX).id(source+customExercise.getId()).doc(doc));
             elasticsearchClient.update(updateRequest, Map.class);
         }catch (Exception e){
             log.error("엘라스틱 업데이트시 문제 발생");
@@ -68,7 +69,7 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
      */
     @Override
     public void deleteExercise(Long customExerciseId) {
-        DeleteRequest deleteRequest = DeleteRequest.of(u -> u.index(INDEX).id(String.valueOf(customExerciseId)));
+        DeleteRequest deleteRequest = DeleteRequest.of(u -> u.index(INDEX).id("custom_"+customExerciseId));
         try {
             elasticsearchClient.delete(deleteRequest);
         }catch (Exception e){

--- a/src/main/java/team9499/commitbody/domain/exercise/service/SchedulingService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/SchedulingService.java
@@ -71,7 +71,7 @@ public class SchedulingService {
                     }
                 }
             }catch (Exception e){
-                throw new ServerException(ExceptionStatus.SERVER_ERROR, ExceptionType.SERVER_ERROR);
+                throw new ServerException(ExceptionStatus.INTERNAL_SERVER_ERROR, ExceptionType.SERVER_ERROR);
             }
 
         }
@@ -87,13 +87,13 @@ public class SchedulingService {
 
         // 기본 운동 목록
         for (Exercise exercise : exerciseList) {
-            ExerciseDoc aDefault = new ExerciseDoc(String.valueOf(exercise.getId()), exercise.getExerciseName(), exercise.getGifUrl(), exercise.getExerciseTarget().name(),
+            ExerciseDoc aDefault = new ExerciseDoc("default_"+exercise.getId(),exercise.getId(), exercise.getExerciseName(), exercise.getGifUrl(), exercise.getExerciseTarget().name(),
                     exercise.getExerciseType().getDescription(), exercise.getExerciseEquipment().getKoreanName(), null, "default", false);
             exerciseDocList.add(aDefault);
         }
         // 커스텀 운동 목록
         for (CustomExercise customExercise : customExercises) {
-            ExerciseDoc custom = new ExerciseDoc(String.valueOf(customExercise.getId()), customExercise.getCustomExName(), customExercise.getCustomGifUrl(), customExercise.getExerciseTarget().name(), null, customExercise.getExerciseEquipment().getKoreanName(), String.valueOf(customExercise.getMember().getId()), "custom",false);
+            ExerciseDoc custom = new ExerciseDoc("custom_"+customExercise.getId(),customExercise.getId(), customExercise.getCustomExName(), customExercise.getCustomGifUrl(), customExercise.getExerciseTarget().name(), null, customExercise.getExerciseEquipment().getKoreanName(), String.valueOf(customExercise.getMember().getId()), "custom",false);
             exerciseDocList.add(custom);
         }
 

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionStatus.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionStatus.java
@@ -5,7 +5,7 @@ public enum ExceptionStatus {
     BAD_REQUEST(400),
     UNAUTHORIZED(401),
     FORBIDDEN(403),
-    SERVER_ERROR(500);
+    INTERNAL_SERVER_ERROR(500);
 
     private final int status;
 

--- a/src/main/java/team9499/commitbody/global/aws/s3/S3ServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/aws/s3/S3ServiceImpl.java
@@ -50,7 +50,7 @@ public class S3ServiceImpl implements S3Service{
                 amazonS3.putObject(new PutObjectRequest(bucketImage, storedFileName, inputStream, objectMetadata));
             } catch (Exception e) {
                 e.printStackTrace();
-                throw new ServerException(ExceptionStatus.SERVER_ERROR, SERVER_ERROR);
+                throw new ServerException(ExceptionStatus.INTERNAL_SERVER_ERROR, SERVER_ERROR);
             }
         }
 
@@ -79,7 +79,7 @@ public class S3ServiceImpl implements S3Service{
             amazonS3.deleteObject(bucketImage,fileName);
         }catch (Exception e){
             log.error("이미지 삭제중 오류 발생");
-            throw new ServerException(ExceptionStatus.SERVER_ERROR,SERVER_ERROR);
+            throw new ServerException(ExceptionStatus.INTERNAL_SERVER_ERROR,SERVER_ERROR);
         }
     }
 

--- a/src/main/java/team9499/commitbody/global/utils/CustomMapper.java
+++ b/src/main/java/team9499/commitbody/global/utils/CustomMapper.java
@@ -26,7 +26,7 @@ public class CustomMapper<T> {
             json = objectMapper.writeValueAsString(ob);
             t = objectMapper.readValue(json, clazz);
         } catch (JsonProcessingException e) {
-            throw new ServerException(ExceptionStatus.SERVER_ERROR, ExceptionType.SERVER_ERROR);
+            throw new ServerException(ExceptionStatus.INTERNAL_SERVER_ERROR, ExceptionType.SERVER_ERROR);
         }
 
         return t;


### PR DESCRIPTION
## 개요
- id값을 잘못 설정하여 데이터가 보존되지 못하는 버그를 구분자를 통한 ID값을 생성하여 중복된 데이터가 덮어 씌워지는 문제를 해결
- 서버 커스텀 예외의 상태 코드 명칭을 변경
- 운동 검색시 데이터가 업데이트되면 필드값의 위치가 변경되어 데이터 변환시 혼잡스러워 직접 데이터를 매핑하는식으로 변경

Resolves: #24 

## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).