### PR TITLE
관심 운동 관련 버그수정 및 QueryDsl 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,9 @@ bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
 application.yml
+application-test.yml
 keystore.p12
+src/main/generated
 
 ### IntelliJ IDEA ###
 .idea

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,14 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.15'
 	implementation 'com.auth0:java-jwt:4.4.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -49,4 +54,18 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -44,7 +44,7 @@ public class ExerciseController {
     @Operation(summary = "운동 검색", description = "운동을 검색합니다. [name: 운동명, target: 부위, equipment: 운동 장비, favorite: 관심운동 여부(true/false), from: 시작 위치, size: 페이지당 표시 데이터 양]")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "EX) - /api/v1/search-exercise?name=인클라인&target=가슴&equipment=맨몸&favorite=false&from=0&size=1", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"성공\", \"data\": {\"totalCount\": 5, \"exercise\": [{\"exerciseId\": \"492\", \"exerciseName\": \"인클라인 푸시업 뎁스 점프\", \"gifUrl\": \"https://EXAMPLE.COM\", \"exerciseTarget\": \"가슴\", \"exerciseType\": \"횟수\", \"exerciseEquipment\": \"맨몸\", \"source\": \"default\", \"favorites\": false}]}}")))
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"성공\", \"data\": {\"totalCount\": 5, \"exercise\": [{\"exerciseId\": \"492\", \"exerciseName\": \"인클라인 푸시업 뎁스 점프\", \"gifUrl\": \"https://EXAMPLE.COM\", \"exerciseTarget\": \"가슴\", \"exerciseType\": \"횟수\", \"exerciseEquipment\": \"맨몸\", \"source\": \"default\", \"interest\": false}]}}")))
     })
     @GetMapping("/search-exercise")
     public ResponseEntity<?> searchExercise(@RequestParam(value = "name",required = false) String name,

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -50,12 +50,12 @@ public class ExerciseController {
     public ResponseEntity<?> searchExercise(@RequestParam(value = "name",required = false) String name,
                                             @RequestParam(value = "target",required = false) String target,
                                             @RequestParam(value = "equipment",required = false)String equipment,
-                                            @RequestParam(value = "favorite",required = false) Boolean favorite,
+                                            @RequestParam(value = "interest",required = false) Boolean interest,
                                             @RequestParam(value = "from",required = false)Integer from,
                                             @RequestParam(value = "size",required = false)Integer size,
                                             @AuthenticationPrincipal PrincipalDetails principalDetails){
         String memberId = String.valueOf(principalDetails.getMember().getId());
-        SearchExerciseResponse searchExerciseResponse = exerciseService.searchExercise(name, target, equipment,from, size, favorite, memberId);
+        SearchExerciseResponse searchExerciseResponse = exerciseService.searchExercise(name, target, equipment,from, size, interest, memberId);
 
         return ResponseEntity.ok(new SuccessResponse<>(true,"성공",searchExerciseResponse));
     }

--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -154,7 +154,7 @@ public class ExerciseController {
                                               @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = principalDetails.getMember().getId();
         String interestStatus = exerciseInterestService.updateInterestStatus(interestExerciseRequest.getExerciseId(), memberId, interestExerciseRequest.getSource());
-        eventPublisher.publishEvent(new ElasticExerciseInterest(interestExerciseRequest.getExerciseId(),interestExerciseRequest.getSource(),interestStatus));
+        eventPublisher.publishEvent(new ElasticExerciseInterest(interestExerciseRequest.getExerciseId(),interestExerciseRequest.getSource(),interestStatus,memberId));
         return ResponseEntity.ok(new SuccessResponse<>(true,interestStatus));
     }
 

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseDoc.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseDoc.java
@@ -47,16 +47,18 @@ public class ExerciseDoc {
     @Field(type = FieldType.Text, name = "source")                  // custom , default
     private String source;
 
-    @Field(type = FieldType.Boolean,name = "favorites")             // 관심운동
-    private Boolean favorites;
+    @Field(type = FieldType.Boolean,name = "interest")             // 관심운동
+    private Boolean interest;
 
 
     public ExerciseDoc customExercise(CustomExercise customExercise,String gifUrl){
         return ExerciseDoc.builder()
                 .id("custom_"+customExercise.getId())
                 .exerciseId(customExercise.getId()).exerciseName(customExercise.getCustomExName()).gifUrl(gifUrl)
-                .exerciseType(null).exerciseEquipment(customExercise.getExerciseEquipment().getKoreanName()).memberId(String.valueOf(customExercise.getMember().getId()))
-                .source("custom").favorites(false).build();
+                .exerciseType(null).exerciseEquipment(customExercise.getExerciseEquipment().getKoreanName())
+                .exerciseTarget(customExercise.getExerciseTarget().name())
+                .memberId(String.valueOf(customExercise.getMember().getId()))
+                .source("custom").interest(false).build();
     }
 
 

--- a/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseInterestDoc.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/domain/ExerciseInterestDoc.java
@@ -1,0 +1,31 @@
+package team9499.commitbody.domain.exercise.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "exercise_interest_index" , writeTypeHint = WriteTypeHint.FALSE)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExerciseInterestDoc {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long memberId;
+
+    @Field(type = FieldType.Long)
+    private Long exerciseId;
+
+    @Field(type = FieldType.Boolean, name = "status")       //관심운동 상태
+    private Boolean status;
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ElasticExerciseInterest.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ElasticExerciseInterest.java
@@ -11,9 +11,12 @@ public class ElasticExerciseInterest {
 
     private String status;
 
-    public ElasticExerciseInterest(Long exerciseId, String source,String status) {
+    private Long memberId;
+
+    public ElasticExerciseInterest(Long exerciseId, String source,String status,Long memberId) {
         this.exerciseId = exerciseId;
         this.source = source;
         this.status = status;
+        this.memberId = memberId;
     }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/event/ExerciseHandler.java
@@ -28,6 +28,6 @@ public class ExerciseHandler {
 
     @EventListener
     public void ElInterestExercise(ElasticExerciseInterest exerciseInterest){
-        exerciseService.changeInterest(exerciseInterest.getExerciseId(), exerciseInterest.getSource(),exerciseInterest.getStatus());
+        exerciseService.changeInterest(exerciseInterest.getExerciseId(), exerciseInterest.getSource(),exerciseInterest.getStatus(),exerciseInterest.getMemberId());
     }
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/repository/ExerciseElsInterestRepository.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/repository/ExerciseElsInterestRepository.java
@@ -1,0 +1,7 @@
+package team9499.commitbody.domain.exercise.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import team9499.commitbody.domain.exercise.domain.ExerciseInterestDoc;
+
+public interface ExerciseElsInterestRepository extends ElasticsearchRepository<ExerciseInterestDoc, Long> {
+}

--- a/src/main/java/team9499/commitbody/domain/exercise/repository/ExerciseInterestRepository.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/repository/ExerciseInterestRepository.java
@@ -7,7 +7,9 @@ import team9499.commitbody.domain.exercise.domain.ExerciseInterest;
 import java.util.Optional;
 
 @Repository
-public interface ExerciseInterestRepository extends JpaRepository<ExerciseInterest, Long> {
+public interface ExerciseInterestRepository extends JpaRepository<ExerciseInterest, Long>{
 
-    Optional<ExerciseInterest> findByIdAndMemberId(Long exerciseId, Long memberId);
+    Optional<ExerciseInterest> findByExerciseIdAndMemberId(Long exerciseId, Long memberId);
+
+    Optional<ExerciseInterest> findByCustomExerciseIdAndMemberId(Long customExerciseId,Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/ElasticExerciseService.java
@@ -8,5 +8,5 @@ public interface ElasticExerciseService {
 
     void deleteExercise(Long customExerciseId);
 
-    void changeInterest(Long exerciseId,String source,String status);
+    void changeInterest(Long exerciseId,String source,String status,Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ElasticExerciseServiceImpl.java
@@ -10,7 +10,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team9499.commitbody.domain.exercise.domain.CustomExercise;
 import team9499.commitbody.domain.exercise.domain.ExerciseDoc;
+import team9499.commitbody.domain.exercise.domain.ExerciseInterestDoc;
 import team9499.commitbody.domain.exercise.repository.CustomExerciseRepository;
+import team9499.commitbody.domain.exercise.repository.ExerciseElsInterestRepository;
 import team9499.commitbody.domain.exercise.repository.ExerciseElsRepository;
 import team9499.commitbody.domain.exercise.service.ElasticExerciseService;
 
@@ -25,6 +27,7 @@ import java.util.Map;
 public class ElasticExerciseServiceImpl implements ElasticExerciseService {
 
     private final CustomExerciseRepository customExerciseRepository;
+    private final ExerciseElsInterestRepository exerciseElsInterestRepository;
     private final ElasticsearchClient elasticsearchClient;
     private final ExerciseElsRepository exerciseElsRepository;
 
@@ -78,17 +81,10 @@ public class ElasticExerciseServiceImpl implements ElasticExerciseService {
     }
 
     @Override
-    public void changeInterest(Long exerciseId, String source,String status) {
+    public void changeInterest(Long exerciseId, String source,String status,Long memberId) {
 
-        Map<String,Object> doc = new HashMap<>();
-        doc.put("favorites", status.equals("등록") ? true : false);
-
-        try {
-            UpdateRequest<Object, Object> updateRequest = UpdateRequest.of(u -> u.index(INDEX).id(source + exerciseId).doc(doc));
-            elasticsearchClient.update(updateRequest,Map.class);
-        }catch (Exception e){
-            log.error("관심 운동 상태 변경시 오류 발생");
-        }
+        ExerciseInterestDoc exerciseInterestDoc = new ExerciseInterestDoc(source + exerciseId+"_"+memberId,memberId, exerciseId, status.equals("등록") ? true : false);
+        exerciseElsInterestRepository.save(exerciseInterestDoc);
 
     }
 

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ExerciseInterestServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ExerciseInterestServiceImpl.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.domain.exercise.service.Impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team9499.commitbody.domain.Member.domain.Member;
@@ -19,6 +20,7 @@ import static team9499.commitbody.global.Exception.ExceptionStatus.*;
 import static team9499.commitbody.global.Exception.ExceptionStatus.INTERNAL_SERVER_ERROR;
 import static team9499.commitbody.global.Exception.ExceptionType.*;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -60,8 +62,13 @@ public class ExerciseInterestServiceImpl implements ExerciseInterestService {
     관심 운동이 저장되어 있지 않을 경우 데이터를 저장하고 저장한 데이터를 반환하는 메서드
      */
     private ExerciseInterest findOrCreateInterest(Long exerciseId, Long memberId, String source, Member member) {
-        return exerciseInterestRepository.findByIdAndMemberId(exerciseId, memberId)
-                .orElseGet(() -> createNewInterest(exerciseId, source, member));
+        if (source.equals(DEFAULT)) {
+            return exerciseInterestRepository.findByExerciseIdAndMemberId(exerciseId, memberId)
+                    .orElseGet(() -> createNewInterest(exerciseId, source, member));
+        }else {
+            return exerciseInterestRepository.findByCustomExerciseIdAndMemberId(exerciseId, memberId)
+                    .orElseGet(() -> createNewInterest(exerciseId, source, member));
+        }
     }
 
     /*

--- a/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ExerciseServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/Impl/ExerciseServiceImpl.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.domain.exercise.service.Impl;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
@@ -42,12 +43,13 @@ public class ExerciseServiceImpl implements ExerciseService {
     private final S3Service s3Service;
 
     private final String INDEX_NAME = "exercise_index";
+    private final String INTEREST_INDEX_NAME = "exercise_interest_index";
     private final String EXERCISE_ID = "exerciseId";
     private final String NAME_FIELD = "exerciseName";
     private final String EQUIPMENT_FIELD = "exerciseEquipment";
     private final String GIF_URL ="gifUrl";
     private final String TARGET_FIELD = "exerciseTarget";
-    private final String FAVORITES_FILED = "favorites";
+    private final String INTEREST_FILED = "interest";
     private final String EXERCISE_TYPE ="exerciseType";
     private final String MEMBER_FILED = "memberId";
     private final String SCORE_FILED = "_score";
@@ -95,7 +97,7 @@ public class ExerciseServiceImpl implements ExerciseService {
         // 관심운동의 대한 동적 쿼리
         if (favorites!=null){
             TermQuery termQuery = new TermQuery.Builder()
-                    .field(FAVORITES_FILED)
+                    .field(INTEREST_FILED)
                     .value(favorites).build();
             boolQueryBuilder.filter(Query.of(builder ->  builder.term(termQuery)));
         }
@@ -132,9 +134,10 @@ public class ExerciseServiceImpl implements ExerciseService {
 
             List<LinkedHashMap<String,Object>> response = new LinkedList<>();
             List<Hit<Object>> hits = searchResponse.hits().hits();
+            List<Long> ids = new ArrayList<>();
             for (Hit<Object> hit : hits) {
                 LinkedHashMap<String, Object> linkedHashMap = new LinkedHashMap<>();
-                Map<String,String> source = (Map<String,String>)hit.source();
+                Map<String,Object> source = (Map<String,Object>)hit.source();
                 linkedHashMap.put(EXERCISE_ID,source.get(EXERCISE_ID));
                 linkedHashMap.put(NAME_FIELD,source.get(NAME_FIELD));
                 linkedHashMap.put(GIF_URL,source.get(GIF_URL));
@@ -142,12 +145,47 @@ public class ExerciseServiceImpl implements ExerciseService {
                 linkedHashMap.put(EXERCISE_TYPE,source.get(EXERCISE_TYPE));
                 linkedHashMap.put(EQUIPMENT_FIELD,source.get(EQUIPMENT_FIELD));
                 linkedHashMap.put("source",source.get("source"));
-                linkedHashMap.put("favorites",source.get("favorites"));
+                linkedHashMap.put(INTEREST_FILED,false);
                 response.add(linkedHashMap);
+                ids.add(Long.valueOf(source.get(EXERCISE_ID).toString()));
             }
 
+            TermsQueryField countryTerms = new TermsQueryField.Builder()
+                    .value(ids.stream().map(FieldValue::of).toList())
+                    .build();
+
+            BoolQuery interestBool = new BoolQuery.Builder()
+                    .must(m -> m.term(t -> t.field(MEMBER_FILED).value(memberId)))
+                    .must(m -> m.term(t -> t.field(MEMBER_FILED).value(memberId)))
+                    .must(m -> m.terms(t -> t.field(EXERCISE_ID).terms(countryTerms))).build();
+
+            SearchRequest interestRequest = new SearchRequest.Builder()
+                    .index(INTEREST_INDEX_NAME)
+                    .query(q -> q.bool(interestBool))       // bool 최소 만족 조건 1 -> or
+                    .build();
+
+            SearchResponse<Object> interestResponse = elasticsearchClient.search(interestRequest, Object.class);
+            List<Hit<Object>> interestHits = interestResponse.hits().hits();
+
+            for (Hit<Object> hit :interestHits){
+                Map<String,Object> source = (Map<String,Object>)hit.source();
+                String exerciseId = source.get(EXERCISE_ID).toString();     // 아이디값 추출
+                Boolean status = (Boolean) source.get("status");            // 관심 상태 추출
+                for (LinkedHashMap<String,Object> val : response){
+                    for (String idKey : val.keySet()){              // map을 반복
+                        if (idKey.equals(EXERCISE_ID)){             //  관심한 운동의 id랑 조회한 운동 id랑 같다면
+                            String valueInResponse = val.get(idKey).toString().trim();
+                            if (exerciseId.equals(valueInResponse)){
+                                val.put(INTEREST_FILED,status);        // 상태변경
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
             return new SearchExerciseResponse(value,response);
         }catch (Exception e){
+            e.printStackTrace();
             throw new ServerException(ExceptionStatus.INTERNAL_SERVER_ERROR, ExceptionType.SERVER_ERROR);
         }
     }

--- a/src/main/java/team9499/commitbody/domain/exercise/service/SchedulingService.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/service/SchedulingService.java
@@ -12,12 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
-import team9499.commitbody.domain.exercise.domain.CustomExercise;
-import team9499.commitbody.domain.exercise.domain.Exercise;
-import team9499.commitbody.domain.exercise.domain.ExerciseDoc;
-import team9499.commitbody.domain.exercise.repository.ExerciseElsRepository;
-import team9499.commitbody.domain.exercise.repository.ExerciseRepository;
-import team9499.commitbody.domain.exercise.repository.CustomExerciseRepository;
+import team9499.commitbody.domain.exercise.domain.*;
+import team9499.commitbody.domain.exercise.repository.*;
 import team9499.commitbody.global.Exception.ExceptionStatus;
 import team9499.commitbody.global.Exception.ExceptionType;
 import team9499.commitbody.global.Exception.ServerException;
@@ -34,6 +30,8 @@ public class SchedulingService {
     private final ExerciseRepository exerciseRepository;
     private final CustomExerciseRepository customExerciseRepository;
     private final ExerciseElsRepository exerciseElsRepository;
+    private final ExerciseInterestRepository exerciseInterestRepository;
+    private final ExerciseElsInterestRepository exerciseElsInterestRepository;
     private final ObjectMapper objectMapper;
 
     @Value("${api.key}")
@@ -41,6 +39,8 @@ public class SchedulingService {
     @Value("${api.url}")
     private String url;
 
+    private final String DEFAULT = "default_";
+    private final String CUSTOM = "custom_";
     /**
      * gifurl이 새벽 3시마다 초기화 되기때문에 새벽 3시 이후에 서버에서 이미지 url을 새롭게 업데이트 하기위한 메서드
      */
@@ -83,20 +83,32 @@ public class SchedulingService {
     public void updateElData(){
         List<Exercise> exerciseList = exerciseRepository.findAll();
         List<CustomExercise> customExercises = customExerciseRepository.findAll();
+        List<ExerciseInterest> exerciseInterests = exerciseInterestRepository.findAll();
         List<ExerciseDoc> exerciseDocList = new ArrayList<>();
+        List<ExerciseInterestDoc> exerciseInterestDocList = new ArrayList<>();
 
         // 기본 운동 목록
         for (Exercise exercise : exerciseList) {
-            ExerciseDoc aDefault = new ExerciseDoc("default_"+exercise.getId(),exercise.getId(), exercise.getExerciseName(), exercise.getGifUrl(), exercise.getExerciseTarget().name(),
+            ExerciseDoc aDefault = new ExerciseDoc(DEFAULT+exercise.getId(),exercise.getId(), exercise.getExerciseName(), exercise.getGifUrl(), exercise.getExerciseTarget().name(),
                     exercise.getExerciseType().getDescription(), exercise.getExerciseEquipment().getKoreanName(), null, "default", false);
             exerciseDocList.add(aDefault);
         }
         // 커스텀 운동 목록
         for (CustomExercise customExercise : customExercises) {
-            ExerciseDoc custom = new ExerciseDoc("custom_"+customExercise.getId(),customExercise.getId(), customExercise.getCustomExName(), customExercise.getCustomGifUrl(), customExercise.getExerciseTarget().name(), null, customExercise.getExerciseEquipment().getKoreanName(), String.valueOf(customExercise.getMember().getId()), "custom",false);
+            ExerciseDoc custom = new ExerciseDoc(CUSTOM+customExercise.getId(),customExercise.getId(), customExercise.getCustomExName(), customExercise.getCustomGifUrl(), customExercise.getExerciseTarget().name(), null, customExercise.getExerciseEquipment().getKoreanName(), String.valueOf(customExercise.getMember().getId()), "custom",false);
             exerciseDocList.add(custom);
         }
 
+        // 관심 운동 목록 업데이트
+        for (ExerciseInterest exerciseInterest : exerciseInterests) {
+            Long memberId = exerciseInterest.getMember().getId();
+            String id;
+            Long exerciseId = (exerciseInterest.getExercise() != null) ? exerciseInterest.getExercise().getId() : exerciseInterest.getCustomExercise().getId();
+            id = (exerciseInterest.getExercise() != null ? DEFAULT : CUSTOM) + exerciseId + memberId;
+            exerciseInterestDocList.add(new ExerciseInterestDoc(id, memberId, exerciseId, exerciseInterest.isInterested()));
+        }
+
         exerciseElsRepository.saveAll(exerciseDocList);
+        exerciseElsInterestRepository.saveAll(exerciseInterestDocList);
     }
 }

--- a/src/main/java/team9499/commitbody/global/config/QueryDslConfig.java
+++ b/src/main/java/team9499/commitbody/global/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package team9499.commitbody.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    public QueryDslConfig(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 개요
- 관심 운동 등록 시 엘라스틱서치에서도 데이터를 업데이트하도록 했지만, 일반 운동의 관심 운동 데이터를 모든 사용자가 공용으로 사용하여, 공용 운동의 관심 운동 필드 값을 true로 변경하면서 타 사용자의 운동도 관심 운동으로 등록된 것으로 표시되는 문제가 발생하여 이를 수정했습니다.
- 데이터 정합성을 위해 엘라스틱 스케쥴링시 관심운동 인덱스로 스케쥴링을 구현했습니다.
- QueryDsl 사용할 예정이어서 의존성 추가민 Config를 작성했습니다. 
- 운동검색 관심운동  @RequestParm 변경

Resolves: #28 

## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).