### PR TITLE
루틴 조회시 세트수 기능 추가

### DIFF
--- a/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseDto.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseDto.java
@@ -5,11 +5,16 @@ import lombok.Builder;
 import lombok.Data;
 import team9499.commitbody.domain.exercise.domain.ExerciseInterest;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
+import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
+
+import java.util.List;
 
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class CustomExerciseDto {
+
+    private Long routineDetailId;
 
     private Long customExerciseId;
 
@@ -25,8 +30,10 @@ public class CustomExerciseDto {
 
     private Integer sets;
 
-    public static CustomExerciseDto of(Long customExerciseId,String exerciseName,String gifUrl,Integer sets,String exerciseType){
-        return CustomExerciseDto.builder().customExerciseId(customExerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).build();
+    private List<RoutineSetsDto> routineSets;
+
+    public static CustomExerciseDto of(Long routineDetailId, Long customExerciseId,String exerciseName,String gifUrl,Integer sets,String exerciseType,List<RoutineSetsDto> routineSetsDtos){
+        return CustomExerciseDto.builder().routineDetailId(routineDetailId).customExerciseId(customExerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).routineSets(routineSetsDtos).build();
     }
 
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/ExerciseDto.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/ExerciseDto.java
@@ -5,11 +5,16 @@ import lombok.Builder;
 import lombok.Data;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
+import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
+
+import java.util.List;
 
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExerciseDto {
+
+    private Long routineDetailId;
 
     private Long exerciseId;
 
@@ -25,7 +30,9 @@ public class ExerciseDto {
 
     private Integer sets;
 
-    public static ExerciseDto of(Long exerciseId, String exerciseName, String gifUrl,Integer sets,String exerciseType){
-        return ExerciseDto.builder().exerciseId(exerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).build();
+    private List<RoutineSetsDto> routineSets;
+
+    public static ExerciseDto of(Long routineDetailId, Long exerciseId, String exerciseName, String gifUrl,Integer sets,String exerciseType,List<RoutineSetsDto> routineSets) {
+        return ExerciseDto.builder().routineDetailId(routineDetailId).exerciseId(exerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).routineSets(routineSets).build();
     }
 }

--- a/src/main/java/team9499/commitbody/domain/routin/domain/RoutineDetails.java
+++ b/src/main/java/team9499/commitbody/domain/routin/domain/RoutineDetails.java
@@ -5,6 +5,8 @@ import lombok.*;
 import team9499.commitbody.domain.exercise.domain.CustomExercise;
 import team9499.commitbody.domain.exercise.domain.Exercise;
 
+import java.util.List;
+
 @Data
 @Entity
 @AllArgsConstructor
@@ -31,6 +33,9 @@ public class RoutineDetails {
     private Routine routine;
     
     private Integer totalSets;      // 총 세트수
+
+    @OneToMany(mappedBy = "routineDetails")
+    private List<RoutineSets> detailsSets;
 
     public static RoutineDetails of(Object exercise, Routine routine){
         RoutineDetailsBuilder routineDetailsBuilder = RoutineDetails.builder().routine(routine);

--- a/src/main/java/team9499/commitbody/domain/routin/domain/RoutineSets.java
+++ b/src/main/java/team9499/commitbody/domain/routin/domain/RoutineSets.java
@@ -1,0 +1,42 @@
+package team9499.commitbody.domain.routin.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class RoutineSets {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "sets_id")
+    private Long id;
+
+    private Integer kg;
+
+    private Integer times;
+
+    private Integer sets;
+
+    @ManyToOne(fetch =  FetchType.LAZY)
+    @JoinColumn(name = "routine_detail_id")
+    private RoutineDetails routineDetails;
+
+    public static RoutineSets ofWeightAndSets(Integer kg, Integer sets, RoutineDetails routineDetails) { // 무게와 세트를 기록
+        return RoutineSets.builder().kg(kg).sets(sets).routineDetails(routineDetails).build();
+    }
+
+    public static RoutineSets ofSets(Integer sets, RoutineDetails routineDetails) { // 세트수만 기록
+        return RoutineSets.builder().sets(sets).routineDetails(routineDetails).build();
+    }
+
+    public static RoutineSets ofTimes(Integer times, RoutineDetails routineDetails) { // 시간만 기록
+        return RoutineSets.builder().times(times).routineDetails(routineDetails).build();
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/routin/dto/RoutineSetsDto.java
+++ b/src/main/java/team9499/commitbody/domain/routin/dto/RoutineSetsDto.java
@@ -1,0 +1,34 @@
+package team9499.commitbody.domain.routin.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Data;
+import team9499.commitbody.domain.routin.domain.RoutineSets;
+
+@Data
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public class RoutineSetsDto {
+
+    private Long setsId;
+
+    private Integer kg;
+
+    private Integer sets;
+
+    private Integer times;
+
+    public static RoutineSetsDto fromDto(RoutineSets routineSets){
+        RoutineSetsDtoBuilder setsDtoBuilder = RoutineSetsDto.builder().setsId(routineSets.getId());
+
+        Integer routineSetsSets = routineSets.getSets();
+        Integer routineSetsKg = routineSets.getKg();
+        Integer routineSetsTimes = routineSets.getTimes();
+
+        if (routineSetsTimes!=null)setsDtoBuilder.times(routineSetsTimes);
+        else if (routineSets!=null && routineSetsKg !=null) setsDtoBuilder.kg(routineSetsKg).sets(routineSetsSets);
+        else setsDtoBuilder.sets(routineSetsSets);
+
+        return setsDtoBuilder.build();
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/routin/repository/RoutineSetsRepository.java
+++ b/src/main/java/team9499/commitbody/domain/routin/repository/RoutineSetsRepository.java
@@ -1,0 +1,13 @@
+package team9499.commitbody.domain.routin.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.domain.routin.domain.RoutineSets;
+
+import java.util.List;
+
+@Repository
+public interface RoutineSetsRepository extends JpaRepository<RoutineSets, Long> {
+
+    List<RoutineSets> findAllByRoutineDetailsId(Long routineDetailsId);
+}

--- a/src/main/java/team9499/commitbody/domain/routin/service/RoutineServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/routin/service/RoutineServiceImpl.java
@@ -12,12 +12,15 @@ import team9499.commitbody.domain.exercise.dto.CustomExerciseDto;
 import team9499.commitbody.domain.exercise.dto.ExerciseDto;
 import team9499.commitbody.domain.exercise.repository.CustomExerciseRepository;
 import team9499.commitbody.domain.exercise.repository.ExerciseRepository;
+import team9499.commitbody.domain.routin.domain.RoutineSets;
 import team9499.commitbody.domain.routin.domain.Routine;
 import team9499.commitbody.domain.routin.domain.RoutineDetails;
 import team9499.commitbody.domain.routin.dto.RoutineDto;
+import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
 import team9499.commitbody.domain.routin.dto.response.MyRoutineResponse;
 import team9499.commitbody.domain.routin.repository.RoutineDetailsRepository;
 import team9499.commitbody.domain.routin.repository.RoutineRepository;
+import team9499.commitbody.domain.routin.repository.RoutineSetsRepository;
 import team9499.commitbody.global.Exception.ExceptionStatus;
 import team9499.commitbody.global.Exception.ExceptionType;
 import team9499.commitbody.global.Exception.NoSuchException;
@@ -32,6 +35,7 @@ public class RoutineServiceImpl implements RoutineService{
 
     private final RoutineRepository routineRepository;
     private final RoutineDetailsRepository routineDetailsRepository;
+    private final RoutineSetsRepository routineSetsRepository;
     private final MemberRepository memberRepository;
     private final ExerciseRepository exerciseRepository;
     private final CustomExerciseRepository customExerciseRepository;
@@ -54,6 +58,28 @@ public class RoutineServiceImpl implements RoutineService{
         // 루틴의 상세 목록 설정 및 저장
         routine.setList(routineDetails);
         routineDetailsRepository.saveAll(routineDetails);
+        List<RoutineSets> routineSets = new ArrayList<>();
+
+        // 루틴 등록시 초기 세트수 저장
+        for (RoutineDetails routineDetail : routineDetails) {
+            Integer totalSets = routineDetail.getTotalSets();
+            switch (totalSets){
+                case 5 ->{
+                    for (int i =0; i<5;i++){
+                        routineSets.add(RoutineSets.ofWeightAndSets(20,10,routineDetail));
+                    }
+                }
+                case 4->{
+                    for (int i = 0; i<4;i++){
+                        routineSets.add(RoutineSets.ofSets(10,routineDetail));
+                    }
+                }
+                default -> {
+                    routineSets.add(RoutineSets.ofTimes(60,routineDetail));
+                }
+            }
+        }
+        routineSetsRepository.saveAll(routineSets);
     }
 
 
@@ -114,14 +140,23 @@ public class RoutineServiceImpl implements RoutineService{
 
     private void addExerciseInfo(RoutineDetails routineDetails, Set<String> targets, List<Object> exercises) {
         Exercise exercise = routineDetails.getExercise(); // 루틴 상세 내 운동 정보를 가져옴
-
+        Long routineDetailsId = routineDetails.getId();
+        
+        List<RoutineSets> allByRoutineDetailsId = routineSetsRepository.findAllByRoutineDetailsId(routineDetailsId);
+        List<RoutineSetsDto> routineSetsDtos = new ArrayList<>();
+        
+        // 루틴의 저장된 각 운동의 세트스를 리스트에 추가
+        for (RoutineSets routineSets : allByRoutineDetailsId) {
+            routineSetsDtos.add(RoutineSetsDto.fromDto(routineSets));
+        }
         if (exercise != null) {             // 기본 운동 정보가 있으면 대상에 추가하고, 운동을 리스트에 추가
+
             targets.add(exercise.getExerciseTarget().name());
-            exercises.add(ExerciseDto.of(exercise.getId(), exercise.getExerciseName(), exercise.getGifUrl(), routineDetails.getTotalSets(),exercise.getExerciseType().getDescription()));
+            exercises.add(ExerciseDto.of(routineDetailsId,exercise.getId(), exercise.getExerciseName(), exercise.getGifUrl(), routineDetails.getTotalSets(),exercise.getExerciseType().getDescription(),routineSetsDtos));
         } else {                // 커스텀 운동 정보가 있으면 대상에 추가하고, 커스텀 운동을 리스트에 추가
             CustomExercise customExercise = routineDetails.getCustomExercise();
             targets.add(customExercise.getExerciseTarget().name());
-            exercises.add(CustomExerciseDto.of(customExercise.getId(), customExercise.getCustomExName(), customExercise.getCustomGifUrl(), routineDetails.getTotalSets(),"무게와 횟수"));
+            exercises.add(CustomExerciseDto.of(routineDetailsId, customExercise.getId(), customExercise.getCustomExName(), customExercise.getCustomGifUrl(), routineDetails.getTotalSets(),"무게와 횟수",routineSetsDtos));
         }
     }
 


### PR DESCRIPTION
## 개요
- 루틴 조회 시 변경된 사항을 사용자가 확인할 수 있도록 세트 수에 대한 값을 저장해야 합니다. 이를 위해 테이블을 생성하고 조회 로직을 변경했습니다

Ref : #31 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).