### PR TITLE
루틴 편집 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseDto.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/CustomExerciseDto.java
@@ -30,10 +30,12 @@ public class CustomExerciseDto {
 
     private Integer sets;
 
+    private Integer orders; // 운동 순서
+
     private List<RoutineSetsDto> routineSets;
 
-    public static CustomExerciseDto of(Long routineDetailId, Long customExerciseId,String exerciseName,String gifUrl,Integer sets,String exerciseType,List<RoutineSetsDto> routineSetsDtos){
-        return CustomExerciseDto.builder().routineDetailId(routineDetailId).customExerciseId(customExerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).routineSets(routineSetsDtos).build();
+    public static CustomExerciseDto of(Long routineDetailId, Long customExerciseId,String exerciseName,String gifUrl,Integer sets,String exerciseType,Integer orders, List<RoutineSetsDto> routineSetsDtos){
+        return CustomExerciseDto.builder().routineDetailId(routineDetailId).customExerciseId(customExerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).orders(orders).exerciseType(exerciseType).routineSets(routineSetsDtos).build();
     }
 
 }

--- a/src/main/java/team9499/commitbody/domain/exercise/dto/ExerciseDto.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/dto/ExerciseDto.java
@@ -1,8 +1,10 @@
 package team9499.commitbody.domain.exercise.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseEquipment;
 import team9499.commitbody.domain.exercise.domain.enums.ExerciseTarget;
 import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
@@ -12,6 +14,8 @@ import java.util.List;
 @Data
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor
+@NoArgsConstructor
 public class ExerciseDto {
 
     private Long routineDetailId;
@@ -30,9 +34,13 @@ public class ExerciseDto {
 
     private Integer sets;
 
+    private Integer orders; // 운동 순서
+
     private List<RoutineSetsDto> routineSets;
 
-    public static ExerciseDto of(Long routineDetailId, Long exerciseId, String exerciseName, String gifUrl,Integer sets,String exerciseType,List<RoutineSetsDto> routineSets) {
-        return ExerciseDto.builder().routineDetailId(routineDetailId).exerciseId(exerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).routineSets(routineSets).build();
+    private String source;
+
+    public static ExerciseDto of(Long routineDetailId, Long exerciseId, String exerciseName, String gifUrl,Integer sets,String exerciseType,Integer orders,List<RoutineSetsDto> routineSets) {
+        return ExerciseDto.builder().routineDetailId(routineDetailId).exerciseId(exerciseId).exerciseName(exerciseName).gifUrl(gifUrl).sets(sets).exerciseType(exerciseType).orders(orders).routineSets(routineSets).build();
     }
 }

--- a/src/main/java/team9499/commitbody/domain/routin/contorller/RoutineController.java
+++ b/src/main/java/team9499/commitbody/domain/routin/contorller/RoutineController.java
@@ -62,6 +62,18 @@ public class RoutineController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",myRoutine));
     }
 
+
+    @Operation(summary = "루틴 편집", description = "사용자가 등록한 루틴을 편집합니다. 필드 별 변경할 데이터가 있는 경우에만 해당 필드를 작성합니다. 변경할 데이터가 없는 경우에는 해당 필드를 작성하지 않습니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"루틴 수정 완료\"}"))),
+            @ApiResponse(responseCode = "400-1",description = "BADREQUEST - 사용할수 없는 토큰", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400-2",description = "BADREQUEST - 데이터 존재하지 않을시", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"해당 정보를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
+    })
     @PutMapping("/routine/{id}")
     public ResponseEntity<?> updateRoutine(@PathVariable("id")Long id,
                                            @RequestBody UpdateRoutineRequest updateRoutineRequest,

--- a/src/main/java/team9499/commitbody/domain/routin/contorller/RoutineController.java
+++ b/src/main/java/team9499/commitbody/domain/routin/contorller/RoutineController.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.routin.dto.response.MyRoutineResponse;
 import team9499.commitbody.domain.routin.dto.rqeust.RoutineRequest;
+import team9499.commitbody.domain.routin.dto.rqeust.UpdateRoutineRequest;
 import team9499.commitbody.domain.routin.service.RoutineService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
 import team9499.commitbody.global.payload.ErrorResponse;
@@ -61,4 +62,13 @@ public class RoutineController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",myRoutine));
     }
 
+    @PutMapping("/routine/{id}")
+    public ResponseEntity<?> updateRoutine(@PathVariable("id")Long id,
+                                           @RequestBody UpdateRoutineRequest updateRoutineRequest,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = principalDetails.getMember().getId();
+        routineService.updateRoutine(id,memberId,updateRoutineRequest.getUpdateRoutineName(),updateRoutineRequest.getDeleteRoutines(),updateRoutineRequest.getUpdateSets(),
+                updateRoutineRequest.getDeleteSets(),updateRoutineRequest.getNewExercises(),updateRoutineRequest.getChangeExercises(),updateRoutineRequest.getChangeOrders());
+        return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 수정 완료"));
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/routin/contorller/RoutineController.java
+++ b/src/main/java/team9499/commitbody/domain/routin/contorller/RoutineController.java
@@ -26,7 +26,6 @@ public class RoutineController {
 
     private final RoutineService routineService;
 
-
     @Operation(summary = "루틴 등록", description = "사용자는 운동 목록을 통해 루틴을 등록가능합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
@@ -49,7 +48,7 @@ public class RoutineController {
     @Operation(summary = "루틴 조회", description = "사용자가 지정한 루틴의 정보를 조회합니다. 커스텀운동의 대한 exerciseType은 무게와 횟수 로 고정됩니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"루틴 등록 성공\",\"data\":{\"routineDtos\":[{\"routineId\":1,\"routineName\":\"루틴제목\",\"targets\":[\"복근\",\"등\"],\"exercises\":[{\"exerciseId\":1,\"exerciseName\":\"3/4 싯업\",\"gifUrl\":\"https://v2.exercisedb.io/image/oAVJS-wlSfNhXd\",\"exerciseType\":\"횟수\",\"sets\":4},{\"customExerciseId\":1,\"exerciseName\":\"커스텀운동명\",\"gifUrl\":\"http://example.com/pushup.gif\",\"exerciseType\":\"무게와 횟수\",\"sets\":4}]}]}}"))),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"루틴 등록 성공\",\"data\":{\"routineDtos\":[{\"routineId\":1,\"routineName\":\"루틴제목\",\"targets\":[\"복근\",\"등\"],\"exercises\":[{\"exerciseId\":1,\"exerciseName\":\"3/4 싯업\",\"gifUrl\":\"https://v2.exercisedb.io/image/oAVJS-wlSfNhXd\",\"exerciseType\":\"횟수\",\"sets\":4,\"orders\" : 1,\"routineSets\" : [{ \"setsId\" : 105, \"sets\" : 1}]},{\"customExerciseId\":1,\"exerciseName\":\"커스텀운동명\",\"gifUrl\":\"http://example.com/pushup.gif\",\"exerciseType\":\"무게와 횟수\",\"sets\":4,\"orders\":2,\"routineSets\" : [{ \"setsId\" : 105, \"sets\" : 2}]}]}]}}"))),
             @ApiResponse(responseCode = "400-3",description = "BADREQUEST - 사용할수 없는 토큰", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
             @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/team9499/commitbody/domain/routin/domain/Routine.java
+++ b/src/main/java/team9499/commitbody/domain/routin/domain/Routine.java
@@ -34,4 +34,8 @@ public class Routine {
         return Routine.builder().member(member).routineName(routineName).build();
     }
 
+    public void updateRoutineName(String routineName){
+        this.routineName = routineName;
+    }
+
 }

--- a/src/main/java/team9499/commitbody/domain/routin/domain/RoutineDetails.java
+++ b/src/main/java/team9499/commitbody/domain/routin/domain/RoutineDetails.java
@@ -77,4 +77,13 @@ public class RoutineDetails {
     public void updateOrders(Integer orders){
         this.orders = orders;
     }
+
+    public void updateExercise(Object exercise){
+        if (exercise instanceof Exercise){
+            this.exercise = (Exercise) exercise;
+        }
+        if (exercise instanceof CustomExercise){
+            this.customExercise = (CustomExercise) exercise;
+        }
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/routin/domain/RoutineDetails.java
+++ b/src/main/java/team9499/commitbody/domain/routin/domain/RoutineDetails.java
@@ -34,8 +34,21 @@ public class RoutineDetails {
     
     private Integer totalSets;      // 총 세트수
 
-    @OneToMany(mappedBy = "routineDetails")
+    private Integer orders;         // 운동 순서
+
+    @OneToMany(mappedBy = "routineDetails",cascade = CascadeType.REMOVE)
     private List<RoutineSets> detailsSets;
+
+    public static RoutineDetails of(Object exercise, Routine routine,Integer orders){
+        RoutineDetailsBuilder routineDetailsBuilder = RoutineDetails.builder().orders(orders).routine(routine);
+        if (exercise instanceof Exercise){
+            routineDetailsBuilder.exercise((Exercise) exercise).totalSets(calculateTotalSets((Exercise) exercise));
+        }else{
+            routineDetailsBuilder.customExercise((CustomExercise) exercise).totalSets(4).orders(orders);
+        }
+        return routineDetailsBuilder.build();
+
+    }
 
     public static RoutineDetails of(Object exercise, Routine routine){
         RoutineDetailsBuilder routineDetailsBuilder = RoutineDetails.builder().routine(routine);
@@ -57,4 +70,11 @@ public class RoutineDetails {
         };
     }
 
+    public void updateTotalSets(Integer totalSets){
+        this.totalSets = totalSets;
+    }
+
+    public void updateOrders(Integer orders){
+        this.orders = orders;
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/routin/domain/RoutineSets.java
+++ b/src/main/java/team9499/commitbody/domain/routin/domain/RoutineSets.java
@@ -1,16 +1,14 @@
 package team9499.commitbody.domain.routin.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@ToString(exclude = "routine_detail_id")
 public class RoutineSets {
 
     @Id
@@ -38,5 +36,18 @@ public class RoutineSets {
 
     public static RoutineSets ofTimes(Integer times, RoutineDetails routineDetails) { // 시간만 기록
         return RoutineSets.builder().times(times).routineDetails(routineDetails).build();
+    }
+
+    public void updateWeightAndSets(Integer kg, Integer sets){
+        this.kg = kg;
+        this.sets = sets;
+    }
+
+    public void updateSets(Integer sets){
+        this.sets = sets;
+    }
+
+    public void updateTimes(Integer times){
+        this.times = times;
     }
 }

--- a/src/main/java/team9499/commitbody/domain/routin/dto/RoutineSetsDto.java
+++ b/src/main/java/team9499/commitbody/domain/routin/dto/RoutineSetsDto.java
@@ -1,13 +1,17 @@
 package team9499.commitbody.domain.routin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import team9499.commitbody.domain.routin.domain.RoutineSets;
 
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class RoutineSetsDto {
 
     private Long setsId;

--- a/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
+++ b/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
@@ -1,2 +1,79 @@
-package team9499.commitbody.domain.routin.dto.rqeust;public class UpdateRoutineRequest {
+package team9499.commitbody.domain.routin.dto.rqeust;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import team9499.commitbody.domain.exercise.dto.ExerciseDto;
+import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
+
+import java.util.List;
+
+@Data
+public class UpdateRoutineRequest {
+
+    private String updateRoutineName;
+
+    private List<Long> deleteRoutines;
+
+    private List<UpdateSets> updateSets;
+
+    private List<DeleteSets> deleteSets;
+
+    private List<ExerciseDto> newExercises;
+
+    private List<ChangeExercise> changeExercises;
+
+    private List<ChangeOrders> changeOrders;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UpdateSets {
+        private Long routineDetailsId;
+        private List<RoutineSetsDto> newSets;
+        private List<RoutineSetsDto> updateSets;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DeleteSets {
+        private Long routineDetailsId;
+        private List<Long> setsIds;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NewRoutines {
+        private String source;
+        private List<ExerciseDto> newExercises;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NewExercise {
+        private Long exerciseId;
+        private List<RoutineSetsDto> sets;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChangeExercise{
+        private Long routineDetailsId;
+        private Long exerciseId;
+        private String source;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class ChangeOrders{
+        private Long routineDetailsId;
+        private Integer orders;
+    }
+
+
 }

--- a/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
+++ b/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
@@ -61,23 +61,6 @@ public class UpdateRoutineRequest {
         @Schema(description = "세트 ID")
         private List<Long> setsIds;
     }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class NewRoutines {
-        private String source;
-        private List<ExerciseDto> newExercises;
-    }
-
-    @Data
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class NewExercise {
-        private Long exerciseId;
-        private List<RoutineSetsDto> sets;
-    }
-
     @Schema(name = "운동 변경")
     @Data
     @AllArgsConstructor
@@ -104,6 +87,5 @@ public class UpdateRoutineRequest {
         @Schema(description = "순서")
         private Integer orders;
     }
-
-
+    
 }

--- a/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
+++ b/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
@@ -1,0 +1,2 @@
+package team9499.commitbody.domain.routin.dto.rqeust;public class UpdateRoutineRequest {
+}

--- a/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
+++ b/src/main/java/team9499/commitbody/domain/routin/dto/rqeust/UpdateRoutineRequest.java
@@ -1,5 +1,6 @@
 package team9499.commitbody.domain.routin.dto.rqeust;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,37 +9,56 @@ import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
 
 import java.util.List;
 
+@Schema(name = "루틴 편집 Request")
 @Data
 public class UpdateRoutineRequest {
 
+    @Schema(description = "업데이트할 루틴명 (선택)")
     private String updateRoutineName;
 
+    @Schema(description = "삭제할 상세 루틴 (선택)")
     private List<Long> deleteRoutines;
 
+    @Schema(description = "수정할 세트 (선택)")
     private List<UpdateSets> updateSets;
 
+    @Schema(description = "삭제할 세트 (선택)")
     private List<DeleteSets> deleteSets;
 
+    @Schema(description = "추가할 운동 (선택),exerciseId, source, sets(총 세트 수) 를 사용해 운동 정보를 전달합니다. 세트수는 운동 별로 세트수 작성")
     private List<ExerciseDto> newExercises;
 
+    @Schema(description = "대체할 운동 (선택)")
     private List<ChangeExercise> changeExercises;
 
+    @Schema(description = "운동 순서 변경 (선택)")
     private List<ChangeOrders> changeOrders;
 
+    
+    @Schema(name = "세트 업데이트")
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     public static class UpdateSets {
+        @Schema(description = "상세 루틴 ID")
         private Long routineDetailsId;
+
+        @Schema(description = "새로운 세트")
         private List<RoutineSetsDto> newSets;
+
+        @Schema(description = "업데이트 세트")
         private List<RoutineSetsDto> updateSets;
     }
 
+    @Schema(name = "세트 삭제")
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     public static class DeleteSets {
+        @Schema(description = "상세 루틴 ID")
         private Long routineDetailsId;
+
+        @Schema(description = "세트 ID")
         private List<Long> setsIds;
     }
 
@@ -58,20 +78,30 @@ public class UpdateRoutineRequest {
         private List<RoutineSetsDto> sets;
     }
 
+    @Schema(name = "운동 변경")
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ChangeExercise{
+        @Schema(description = "상세 루틴 ID")
         private Long routineDetailsId;
+
+        @Schema(description = "운동 ID")
         private Long exerciseId;
+
+        @Schema(description = "운동 타입[default,custom]")
         private String source;
     }
 
+    @Schema(name = "운동 순서 변경")
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ChangeOrders{
+        @Schema(description = "상세 루틴 ID")
         private Long routineDetailsId;
+
+        @Schema(description = "순서")
         private Integer orders;
     }
 

--- a/src/main/java/team9499/commitbody/domain/routin/repository/RoutineRepository.java
+++ b/src/main/java/team9499/commitbody/domain/routin/repository/RoutineRepository.java
@@ -5,9 +5,10 @@ import org.springframework.stereotype.Repository;
 import team9499.commitbody.domain.routin.domain.Routine;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoutineRepository extends JpaRepository<Routine,Long> {
     List<Routine> findAllByMemberId(Long memberId);
-
+    Optional<Routine> findByIdAndMemberId(Long routineId, Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/routin/repository/RoutineSetsRepository.java
+++ b/src/main/java/team9499/commitbody/domain/routin/repository/RoutineSetsRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface RoutineSetsRepository extends JpaRepository<RoutineSets, Long> {
 
     List<RoutineSets> findAllByRoutineDetailsId(Long routineDetailsId);
+    RoutineSets findByIdAndRoutineDetailsId(Long setsId, Long routineDetailsId);
+    void deleteByIdAndRoutineDetailsId(Long setsId, Long routineDetailsId);
 }

--- a/src/main/java/team9499/commitbody/domain/routin/service/RoutineService.java
+++ b/src/main/java/team9499/commitbody/domain/routin/service/RoutineService.java
@@ -1,11 +1,18 @@
 package team9499.commitbody.domain.routin.service;
 
+import team9499.commitbody.domain.exercise.dto.ExerciseDto;
 import team9499.commitbody.domain.routin.dto.response.MyRoutineResponse;
 
 import java.util.List;
+
+import static team9499.commitbody.domain.routin.dto.rqeust.UpdateRoutineRequest.*;
 
 public interface RoutineService {
     void saveRoutine(Long memberId, List<Long> exerciseIds, List<Long> customExerciseIds, String routineName);
 
     MyRoutineResponse getMyRoutine(Long memberId);
+
+    void updateRoutine(Long routineId, Long memberId, String routineName, List<Long> deleteRoutines, List<UpdateSets> updateSets,
+                       List<DeleteSets> deleteSets, List<ExerciseDto> newExercises, List<ChangeExercise> changeExercises, List<ChangeOrders> changeOrders);
+
 }

--- a/src/main/java/team9499/commitbody/domain/routin/service/RoutineServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/routin/service/RoutineServiceImpl.java
@@ -28,6 +28,8 @@ import team9499.commitbody.global.Exception.ServerException;
 
 import java.util.*;
 
+import static team9499.commitbody.domain.routin.dto.rqeust.UpdateRoutineRequest.*;
+
 @Slf4j
 @Service
 @Transactional
@@ -41,6 +43,7 @@ public class RoutineServiceImpl implements RoutineService{
     private final ExerciseRepository exerciseRepository;
     private final CustomExerciseRepository customExerciseRepository;
 
+    private final String DEFAULT ="default";
     @Override
     public void saveRoutine(Long memberId, List<Long> exerciseIds, List<Long> customExerciseIds, String routineName) {
         Member member = memberRepository.findById(memberId)
@@ -123,6 +126,160 @@ public class RoutineServiceImpl implements RoutineService{
             }
         }
         return new MyRoutineResponse(routineDtos);    // 변환된 루틴 DTO 리스트를 MyRoutineResponse로 반환
+    }
+
+    /**
+     * 루틴 편집에 사용되는 메서드
+     * 값이 NULL 아닐시에만  사용되도록 작성
+     * @param routineId 최상위 루틴 Id
+     * @param memberId 로그인한 사용자 Id
+     * @param routineName 변경할 루틴 명
+     * @param deleteRoutines 삭제할 상세루틴 아이디 목록
+     * @param updateSets 업데이트할 세트수 목록
+     * @param deleteSets 삭제할 세트수 목록
+     * @param newExercises 새로 추가할 운동 목록
+     * @param changeExercises 운동을 대채할 운동 목록
+     * @param changeOrders 운동의 순서를 변경 목록
+     */
+    @Override
+    public void updateRoutine(Long routineId, Long memberId, String routineName, List<Long> deleteRoutines, List<UpdateSets> updateSets, List<DeleteSets> deleteSets,
+                              List<ExerciseDto> newExercises, List<ChangeExercise> changeExercises,List<ChangeOrders> changeOrders) {
+
+        // 사용자가 작성한 루틴 조회
+        Routine routine = routineRepository.findByIdAndMemberId(routineId, memberId)
+                .orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+
+        // 변경할 루틴명이 존재시
+        if (routineName != null) {
+            routine.updateRoutineName(routineName);
+        }
+
+        // 삭제할 상세 루틴이 존재시
+        if (deleteRoutines != null) {
+            routineDetailsRepository.deleteAllById(deleteRoutines);
+        }
+
+        // 변경할 세트스 존재시
+        if (updateSets != null) {
+            for (UpdateSets updateSet : updateSets) {
+                Long routineDetailsId = updateSet.getRoutineDetailsId();
+                // 세트수 변경시
+                if (updateSet.getUpdateSets() != null) {
+                    for (RoutineSetsDto routineSet : updateSet.getUpdateSets()) {
+                        RoutineSets routineSets = routineSetsRepository.findByIdAndRoutineDetailsId(routineSet.getSetsId(), routineDetailsId);
+                        Integer sets = routineSet.getSets();
+                        Integer kg = routineSet.getKg();
+                        Integer times = routineSet.getTimes();
+                        if (sets != null & kg != null) {
+                            routineSets.updateWeightAndSets(kg, sets);
+                        } else if (times != null) {
+                            routineSets.updateTimes(times);
+                        } else
+                            routineSets.updateSets(sets);
+                    }
+                }
+                // 새로 등록할 세트스가 존재시
+                if (updateSet.getNewSets() != null) {
+                    RoutineDetails routineDetails = getRoutineDetails(updateSet.getRoutineDetailsId());
+                    for (RoutineSetsDto newSet : updateSet.getNewSets()) {
+                        routinesSets(routineDetails, newSet);
+                        routineDetails.updateTotalSets(routineDetails.getTotalSets() + 1);
+                    }
+                }
+            }
+        }
+
+        // 삭제할 세트수 존재시
+        if (deleteSets != null) {
+            for (DeleteSets deleteSet : deleteSets) {
+                Long routineDetailsId = deleteSet.getRoutineDetailsId();
+                RoutineDetails routineDetails = getRoutineDetails(routineDetailsId);
+                for (Long setsId : deleteSet.getSetsIds()) {
+                    routineSetsRepository.deleteByIdAndRoutineDetailsId(setsId, routineDetailsId);
+                    routineDetails.updateTotalSets(routineDetails.getTotalSets() - 1);
+                }
+            }
+        }
+
+        // 새로운 운동 목록 존재시
+        if (newExercises != null) {
+            for (ExerciseDto newExercise : newExercises) {
+                RoutineDetails newRoutineDetails;
+
+                if (newExercise.getSource().equals(DEFAULT)) {
+                    Exercise exercise = getExercise(newExercise.getExerciseId());       // 운동 객체 조회
+                    newRoutineDetails = RoutineDetails.of(exercise, routine);
+                } else {
+                    CustomExercise customExercise = getCustomExercise(newExercise.getExerciseId());
+                    newRoutineDetails = RoutineDetails.of(customExercise, routine);
+                }
+                RoutineDetails routineDetails = routineDetailsRepository.save(newRoutineDetails);
+
+                // 새로운 루틴 세트 등록
+                for (RoutineSetsDto set : newExercise.getRoutineSets()) {
+                    routinesSets(routineDetails, set);
+                }
+            }
+        }
+
+        // 대채 운동 존재시
+        if (changeExercises != null) {
+            for (ChangeExercise changeExercise : changeExercises) {
+                RoutineDetails routineDetails = getRoutineDetails(changeExercise.getRoutineDetailsId());
+
+                String source = changeExercise.getSource();
+                Long exerciseId = changeExercise.getExerciseId();
+                Object exercise;
+                if (source.equals(DEFAULT)){      // 기본 운동 일시
+                    exercise = getExercise(exerciseId);
+                }else                               // 커스텀 운동 일시
+                    exercise = getCustomExercise(exerciseId);
+
+                routineDetails.updateExercise(exercise);
+            }
+        }
+
+        // 운동 순서 변경시
+        if (changeOrders!=null){
+            for (ChangeOrders changeOrder : changeOrders) {
+                RoutineDetails routineDetails = getRoutineDetails(changeOrder.getRoutineDetailsId());
+                routineDetails.updateOrders(changeOrder.getOrders());
+            }
+        }
+
+    }
+
+    private CustomExercise getCustomExercise(Long exerciseId) {
+        return customExerciseRepository.findById(exerciseId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+    }
+
+    private Exercise getExercise(Long exerciseId) {
+        return exerciseRepository.findById(exerciseId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+    }
+
+    /**
+     * 루틴별로 세트수를 추가할떄 사용되는 메서드
+     * 운동 타입별로 운동 세트 저장 상이
+     */
+    private void routinesSets(RoutineDetails routineDetails, RoutineSetsDto newSet) {
+        Integer sets = newSet.getSets();        // 세트수
+        Integer kg = newSet.getKg();            // kg
+        Integer times = newSet.getTimes();      // 시간수
+        RoutineSets routineSets;
+        if (sets != null & kg != null) {        // 무게-세트 기준
+            routineSets = RoutineSets.ofWeightAndSets(kg,sets, routineDetails);
+        } else if (times != null) {             // 시간 기준
+            routineSets = RoutineSets.ofTimes(times, routineDetails);
+        } else                                  // 세트 기준
+            routineSets = RoutineSets.ofSets(sets, routineDetails);
+        routineSetsRepository.save(routineSets);
+    }
+
+    /**
+     * 상세 루틴의 정보를 조회
+     */
+    private RoutineDetails getRoutineDetails(Long  routineDetailsId) {
+        return routineDetailsRepository.findById(routineDetailsId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
     }
 
     // orders 기준으로 정렬


### PR DESCRIPTION
## 개요
- 루틴 편집 시 상세 루틴 운동 순서 변경을 위해 상세 루틴 도메인에 orders 필드를 추가하여 순서를 저장할 수 있도록 했습니다.
- 루틴 편집 시 변경할 루틴의 상세 정보만 편집할 수 있도록 구현했습니다.
-  Swagger 문서를 작성했습니다.
- 미사용 전역 클래스를 삭제했습니다.


Ref : #30 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [X] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).