### PR TITLE
운동 기록 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -47,6 +47,19 @@ public class RecordController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 성공"));
     }
 
+    @Operation(summary = "기록 조회", description = "사용자가 완료한 기록의 대한 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"조회 성공\",\"data\":{\"recordId\":1,\"recordName\":\"나의 첫 번째 기록\",\"startDate\":\"2024.08.14.(수)\",\"durationTime\":\"6:46~8:46\",\"duration\":120,\"recordVolume\":85,\"recordSets\":11,\"recordCalorie\":414,\"details\":[{\"recordDetailId\":1,\"exerciseId\":1,\"gifUrl\":\"https://example.com\",\"detailsReps\":12,\"detailsSets\":2,\"maxReps\":7,\"sets\":[{\"setId\":191,\"reps\":6},{\"setId\":192,\"reps\":7}]}]}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 정보 미존재 시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"해당 정보를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "400_3", description = "BADREQUEST - 존재하지 않는 시용자 요청시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
+    })
     @GetMapping("/record/{id}")
     public ResponseEntity<?> getRecord(@PathVariable("id") Long id,
                                        @AuthenticationPrincipal PrincipalDetails principalDetails){

--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -10,11 +10,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.record.dto.request.RecordRequest;
+import team9499.commitbody.domain.record.dto.response.RecordResponse;
 import team9499.commitbody.domain.record.service.RecordService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
 import team9499.commitbody.global.payload.ErrorResponse;
@@ -47,6 +45,14 @@ public class RecordController {
         Long memberId = principalDetails.getMember().getId();
         recordService.saveRecord(memberId, recordRequest.getRecordName(), recordRequest.getStartTime(),recordRequest.getEndTime(),recordRequest.getExercises());
         return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 성공"));
+    }
+
+    @GetMapping("/record/{id}")
+    public ResponseEntity<?> getRecord(@PathVariable("id") Long id,
+                                       @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = principalDetails.getMember().getId();
+        RecordResponse recordResponse = recordService.getRecord(id, memberId);
+        return  ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",recordResponse));
     }
 
 }

--- a/src/main/java/team9499/commitbody/domain/record/dto/response/RecordDetailsResponse.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/response/RecordDetailsResponse.java
@@ -1,0 +1,56 @@
+package team9499.commitbody.domain.record.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import team9499.commitbody.domain.exercise.domain.CustomExercise;
+import team9499.commitbody.domain.exercise.domain.Exercise;
+
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RecordDetailsResponse {
+
+    private Long recordDetailId;
+    private Long exerciseId;
+    private Long customExerciseId;
+    private String gifUrl;              // gif주소
+    private Integer detailsReps;        // 횟수
+    private Integer detailsSets;        // 세트수
+    private Integer detailsTimes;       // 누적시간
+    private Integer detailsVolume;
+    private Integer maxReps;
+    private Integer max1RM;
+    private List<RecordSetsResponse> sets;
+
+    public static RecordDetailsResponse of(Long recordDetailId, Exercise exercise, CustomExercise customExercise, Integer detailsReps, Integer detailsSets, Integer detailsTimes, Integer detailsVolume, Integer maxReps, Integer max1RM, List<RecordSetsResponse> sets){
+        RecordDetailsResponseBuilder recordDetailsResponseBuilder = RecordDetailsResponse.builder().recordDetailId(recordDetailId).detailsSets(detailsSets);
+        if(exercise!=null){
+            recordDetailsResponseBuilder.exerciseId(exercise.getId()).gifUrl(exercise.getGifUrl());
+        }else{
+            recordDetailsResponseBuilder.customExerciseId(customExercise.getId());
+            if (customExercise.getCustomGifUrl() != null){
+                recordDetailsResponseBuilder.gifUrl(customExercise.getCustomGifUrl());
+            }
+        }
+
+
+        if (detailsTimes!=null){
+            recordDetailsResponseBuilder.detailsTimes(detailsTimes);
+        } else if (maxReps!=null) {
+            recordDetailsResponseBuilder.detailsReps(detailsReps).maxReps(maxReps);
+        }else {
+            recordDetailsResponseBuilder.detailsReps(detailsReps).detailsVolume(detailsVolume).max1RM(max1RM);
+        }
+
+        return recordDetailsResponseBuilder.build();
+
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/record/dto/response/RecordResponse.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/response/RecordResponse.java
@@ -1,0 +1,24 @@
+package team9499.commitbody.domain.record.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecordResponse {
+
+    private Long recordId;
+    private String recordName;
+    private String startDate;       // 운동 시작 날짜 및 시간
+    private String durationTime;    // 운동 시간 (예: "60분")
+    private Integer duration;       // 운동 시간 (분 단위, 예: 60)
+    private Integer recordVolume;   // 볼륨 (kg 단위, 예: 100)
+    private Integer recordSets;     // 세트 수 (예: 40)
+    private Integer recordCalorie;  // 소모 칼로리 (kcal 단위, 예: 200)
+    private List<RecordDetailsResponse> details;
+
+}

--- a/src/main/java/team9499/commitbody/domain/record/dto/response/RecordSetsResponse.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/response/RecordSetsResponse.java
@@ -1,0 +1,31 @@
+package team9499.commitbody.domain.record.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RecordSetsResponse {
+
+    private Long setId;
+    private Integer weight;
+    private Integer reps;
+    private Integer times;
+
+    public static RecordSetsResponse of(Long id, Integer weight, Integer reps, Integer times){
+        RecordSetsResponseBuilder builder = RecordSetsResponse.builder().setId(id);
+        if (weight!=null && reps !=null){
+            builder.weight(weight).reps(reps);
+        }else if (times!=null){
+            builder.times(times);
+        }else
+            builder.reps(reps);
+        return builder.build();
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepository.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepository.java
@@ -1,0 +1,8 @@
+package team9499.commitbody.domain.record.repository;
+
+import team9499.commitbody.domain.record.dto.response.RecordResponse;
+
+public interface CustomRecordRepository {
+
+    RecordResponse findByRecordId(Long recordId, Long memberId);
+}

--- a/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepositoryImpl.java
@@ -1,0 +1,147 @@
+package team9499.commitbody.domain.record.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.domain.exercise.domain.CustomExercise;
+import team9499.commitbody.domain.exercise.domain.Exercise;
+import team9499.commitbody.domain.record.domain.*;
+import team9499.commitbody.domain.record.domain.Record;
+import team9499.commitbody.domain.record.dto.response.RecordDetailsResponse;
+import team9499.commitbody.domain.record.dto.response.RecordResponse;
+import team9499.commitbody.domain.record.dto.response.RecordSetsResponse;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.Exception.NoSuchException;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.TextStyle;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static team9499.commitbody.domain.record.domain.QRecord.*;
+import static team9499.commitbody.domain.record.domain.QRecordDetails.*;
+import static team9499.commitbody.domain.record.domain.QRecordSets.*;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class CustomRecordRepositoryImpl implements CustomRecordRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    /**
+     * 루틴을 완료시 저장된 루틴 정보를 조회하기 위핸 쿼리
+     * 사용자의 루틴만 볼 수 있다.
+     * @param recordId  기록 ID
+     * @param memberId  사용자 ID
+     */
+    @Override
+    public RecordResponse findByRecordId(Long recordId, Long memberId) {
+
+        List<Tuple> list = jpaQueryFactory.select(record,recordDetails,recordSets).from(record)
+                .join(recordDetails).on(record.id.eq(recordDetails.record.id))
+                .join(recordSets).on(recordSets.recordDetails.id.eq(recordDetails.id))
+                .where(record.id.eq(recordId).and(record.member.id.eq(memberId))).fetch();
+
+        // Tuple 리스트를 Record를 키로 하고, RecordDetailsResponse 리스트를 값으로 가지는 Map으로 그룹화
+        Map<Record, List<RecordDetailsResponse>> groupedDetails = list.stream().collect(Collectors.groupingBy(
+                tuple -> tuple.get(0, Record.class),
+                Collectors.mapping(
+                        tuple -> {
+                            // RecordDetails에서 Exercise와 CustomExercise의 null 처리
+                            RecordDetails recordDetail = tuple.get(1, RecordDetails.class);
+                            Exercise exercise = Optional.ofNullable(recordDetail.getExercise())
+                                    .orElse(null);
+                            CustomExercise customExercise = Optional.ofNullable(recordDetail.getCustomExercise())
+                                    .orElse(null);
+                            
+                            // RecordDetailsResponse 객체를 생성하여 반환
+                            return RecordDetailsResponse.of(
+                                    recordDetail.getId(),
+                                    exercise,
+                                    customExercise,
+                                    recordDetail.getDetailsReps(),
+                                    recordDetail.getDetailsSets(),
+                                    recordDetail.getSumTimes(),
+                                    recordDetail.getDetailsVolume(),
+                                    recordDetail.getMaxReps(),
+                                    recordDetail.getMax1RM(),
+                                    new ArrayList<>()
+                            );
+                        },
+                        Collectors.toList()  // 생성된 RecordDetailsResponse를 리스트로 변환
+                )
+        ));
+
+        // 그룹화된 Map의 엔트리를 스트림으로 변환하여 처리
+        return groupedDetails.entrySet().stream().map(entry -> {
+            Record record = entry.getKey(); // 각 엔트리의 키인 Record 객체
+            List<RecordDetailsResponse> details = entry.getValue(); // 각 엔트리의 값인 RecordDetailsResponse 리스트
+
+            // RecordDetailId를 키로 하고, RecordDetailsResponse를 값으로 가지는 Map을 생성
+            Map<Long, RecordDetailsResponse> detailsMap = new LinkedHashMap<>();
+            details.forEach(detail -> detailsMap.put(detail.getRecordDetailId(), detail));
+
+            // 리스트를 다시 순회하며 RecordSets 정보를 RecordDetailsResponse에 추가
+            list.stream().filter(tuple -> tuple.get(1, RecordDetails.class) != null)
+                    .forEach(tuple -> {
+                Long detailId = tuple.get(1, RecordDetails.class).getId();
+                RecordSets recordSets = tuple.get(2, RecordSets.class);
+
+                if (detailsMap.containsKey(detailId)) {      // 해당 detailId를 키로 가진 RecordDetailsResponse가 있으면
+                    RecordDetailsResponse detail = detailsMap.get(detailId);
+                    List<RecordSetsResponse> sets = detail.getSets();
+                    if (sets == null) {
+                        sets = new ArrayList<>();        // sets 리스트가 null인 경우 새로운 ArrayList로 초기화
+                    }
+                    sets.add(RecordSetsResponse.of(
+                            recordSets.getId(),
+                            recordSets.getWeight(),
+                            recordSets.getReps(),
+                            recordSets.getTimes()
+                    )); // 현재의 RecordSets 정보를 RecordSetsResponse로 변환하여 sets 리스트에 추가
+                    detail.setSets(sets);   // 업데이트된 sets 리스트를 RecordDetailsResponse에 설정
+                }
+            });
+
+            return new RecordResponse(
+                    record.getId(),
+                    record.getRecordName(),
+                    converterTime(record),
+                    converterDurationTime(record),
+                    record.getDuration(),
+                    record.getRecordVolume(),
+                    record.getRecordSets(),
+                    record.getRecordCalorie(),
+                    new ArrayList<>(detailsMap.values())
+            );
+        }).findFirst().orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+    }
+
+    /*
+    운동 시작 시간과 운동 끝시간을 18:14~20:15 로변환 하는메서드
+     */
+    private  String converterDurationTime(Record record) {
+        StringBuilder sb =new StringBuilder();
+        LocalDateTime startTime = record.getStartTime();
+        LocalDateTime endTime = record.getEndTime();
+
+        return sb.append(startTime.getHour()).append(":").append(startTime.getMinute()).append("~").append(endTime.getHour()).append(":").append(endTime.getMinute()).toString();
+    }
+
+    /*
+    LocalDateTime을 2024.08.25.(금) 형식으로변경
+     */
+    private String converterTime(Record record) {
+        LocalDateTime startTime = record.getStartTime();
+        String string = LocalDate.of(startTime.getYear(), startTime.getMonth(), startTime.getDayOfMonth()).toString().toString().replace('-', '.');
+        DayOfWeek dayOfWeek = startTime.getDayOfWeek();
+        String displayName = dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREA);
+        return string + ".(" + displayName + ")";
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/record/repository/RecordRepository.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/RecordRepository.java
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository;
 import team9499.commitbody.domain.record.domain.Record;
 
 @Repository
-public interface RecordRepository extends JpaRepository<Record, Long> {
+public interface RecordRepository extends JpaRepository<Record, Long>, CustomRecordRepository {
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.domain.record.service;
 
 import team9499.commitbody.domain.record.dto.RecordDto;
+import team9499.commitbody.domain.record.dto.response.RecordResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -8,4 +9,6 @@ import java.util.List;
 public interface RecordService {
 
     void saveRecord(Long memberId , String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos);
+
+    RecordResponse getRecord(Long memberId, Long recordId);
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
@@ -10,5 +10,5 @@ public interface RecordService {
 
     void saveRecord(Long memberId , String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos);
 
-    RecordResponse getRecord(Long memberId, Long recordId);
+    RecordResponse getRecord(Long recordId,Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
@@ -142,7 +142,7 @@ public class RecordServiceImpl implements RecordService{
 
     @Transactional(readOnly = true)
     @Override
-    public RecordResponse getRecord(Long memberId, Long recordId) {
+    public RecordResponse getRecord(Long recordId,Long memberId) {
         return recordRepository.findByRecordId(recordId,memberId);
     }
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
@@ -14,6 +14,7 @@ import team9499.commitbody.domain.record.domain.RecordDetails;
 import team9499.commitbody.domain.record.domain.RecordSets;
 import team9499.commitbody.domain.record.dto.RecordDto;
 import team9499.commitbody.domain.record.dto.RecordSetsDto;
+import team9499.commitbody.domain.record.dto.response.RecordResponse;
 import team9499.commitbody.domain.record.repository.RecordDetailsRepository;
 import team9499.commitbody.domain.record.repository.RecordRepository;
 import team9499.commitbody.domain.record.repository.RecordSetsRepository;
@@ -137,5 +138,11 @@ public class RecordServiceImpl implements RecordService{
         recordRepository.save(record);
         recordDetailsRepository.saveAll(recordDetails);
         recordSetsRepository.saveAll(recordSets);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public RecordResponse getRecord(Long memberId, Long recordId) {
+        return recordRepository.findByRecordId(recordId,memberId);
     }
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
@@ -99,7 +99,7 @@ public class RecordServiceImpl implements RecordService{
                 if (weight !=null && reps!=null){       // 무게+횟수일때
                     recordSets.add(RecordSets.ofWeightAndSets(weight,reps,recordDetail));
                     totalVolume += weight;
-                    detailsVolume += weight;
+                    detailsVolume += (weight*reps);
                     detailsReps += reps;
                     weightValid =true;
                     maxRm += Math.round((float)weight * (float)(1 +0.03333*reps));      // 칼로리 계산


### PR DESCRIPTION
## 개요
- 사용자가 완료한 운동 기록을 조회하기 위한 API 구현
- 작성자가 기록한 운동의 대해서만 조회 가능
- 운동 기록 저장 시 총 볼륨 계산 로직 수정

Resolves: #37 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).