### PR TITLE
운동 상세 조회시 버그수정

### DIFF
--- a/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
+++ b/src/main/java/team9499/commitbody/domain/exercise/contorller/ExerciseController.java
@@ -175,7 +175,7 @@ public class ExerciseController {
     public ResponseEntity<?> getDetailExercise(@PathVariable("id") Long id, @RequestParam("source")String source,
                                   @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = principalDetails.getMember().getId();
-        ExerciseResponse exerciseResponse = exerciseService.detailsExercise(memberId, id, source);
+        ExerciseResponse exerciseResponse = exerciseService.detailsExercise(id,memberId,source);
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",exerciseResponse));
     }
 }


### PR DESCRIPTION
## 개요
- 운동 상세조회시 파라미터의 memberId와 exerciseId의 위치가 바뀌어있어 올바른 데이터를 입력해도 데이터가 없는 오류 가발생하여 위치 변경

## PR 유형

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).