### PR TITLE
기록 수정 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.domain.record.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -69,8 +70,19 @@ public class RecordController {
         return  ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",recordResponse));
     }
 
+    @Operation(summary = "기록 수정", description = "사용자가 완료한 기록의 정보를 수정 합니다.(운동 순서, 새 운동 추가,운동 삭제, 세트 추가/삭제/업데이트)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"기록 수정 완료\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 정보 미존재 시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"해당 정보를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
+    })
     @PutMapping("/record/{recordId}")
-    public ResponseEntity<?> updateRoutine(@PathVariable("recordId")Long recordId,
+    public ResponseEntity<?> updateRoutine(@Parameter(description = "기록 ID") @PathVariable("recordId")Long recordId,
                                            @RequestBody UpdateRecordRequest updateRecordRequest,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = getMemberId(principalDetails);

--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -26,10 +26,10 @@ public class RecordController {
 
     private final RecordService recordService;
 
-    @Operation(summary = "기록 저장", description = "루틴 완료시 수행한 운동의 대해 기록을 저장합니다.")
+    @Operation(summary = "기록 저장", description = "루틴 완료시 수행한 운동의 대해 기록을 저장합니다. 저장시 정장된 recordId를 반환합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"루틴 성공\"}"))),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"루틴 성공\",\"data\":1}"))),
             @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
             @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 정보 미존재 시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
@@ -43,8 +43,8 @@ public class RecordController {
     public ResponseEntity<?> saveRecord(@RequestBody RecordRequest recordRequest,
                                      @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = principalDetails.getMember().getId();
-        recordService.saveRecord(memberId, recordRequest.getRecordName(), recordRequest.getStartTime(),recordRequest.getEndTime(),recordRequest.getExercises());
-        return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 성공"));
+        Long recordId = recordService.saveRecord(memberId, recordRequest.getRecordName(), recordRequest.getStartTime(), recordRequest.getEndTime(), recordRequest.getExercises());
+        return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 성공",recordId));
     }
 
     @Operation(summary = "기록 조회", description = "사용자가 완료한 기록의 대한 정보를 조회합니다.")

--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.record.dto.request.RecordRequest;
+import team9499.commitbody.domain.record.dto.request.UpdateRecordRequest;
 import team9499.commitbody.domain.record.dto.response.RecordResponse;
 import team9499.commitbody.domain.record.service.RecordService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
@@ -42,7 +43,7 @@ public class RecordController {
     @PostMapping("/record")
     public ResponseEntity<?> saveRecord(@RequestBody RecordRequest recordRequest,
                                      @AuthenticationPrincipal PrincipalDetails principalDetails){
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = getMemberId(principalDetails);
         Long recordId = recordService.saveRecord(memberId, recordRequest.getRecordName(), recordRequest.getStartTime(), recordRequest.getEndTime(), recordRequest.getExercises());
         return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 성공",recordId));
     }
@@ -63,9 +64,22 @@ public class RecordController {
     @GetMapping("/record/{id}")
     public ResponseEntity<?> getRecord(@PathVariable("id") Long id,
                                        @AuthenticationPrincipal PrincipalDetails principalDetails){
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = getMemberId(principalDetails);
         RecordResponse recordResponse = recordService.getRecord(id, memberId);
         return  ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",recordResponse));
     }
 
+    @PutMapping("/record/{recordId}")
+    public ResponseEntity<?> updateRoutine(@PathVariable("recordId")Long recordId,
+                                           @RequestBody UpdateRecordRequest updateRecordRequest,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = getMemberId(principalDetails);
+        recordService.updateRecord(memberId,recordId,updateRecordRequest.getUpdateSets(),updateRecordRequest.getNewExercises(),updateRecordRequest.getDeleteSetIds(),updateRecordRequest.getDeleteDetailsIds(),updateRecordRequest.getChangeOrders());
+        return ResponseEntity.ok(new SuccessResponse<>(true,"기록 수정 완료"));
+    }
+
+    private static Long getMemberId(PrincipalDetails principalDetails) {
+        Long memberId = principalDetails.getMember().getId();
+        return memberId;
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/record/domain/Record.java
+++ b/src/main/java/team9499/commitbody/domain/record/domain/Record.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import team9499.commitbody.domain.Member.domain.Member;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Entity
@@ -38,6 +40,9 @@ public class Record {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "record", cascade = CascadeType.ALL)
+    private List<RecordDetails> detailsList = new ArrayList<>();
 
     public static Record create(String recordName, LocalDateTime startTime, LocalDateTime endTime,Integer duration, Member member){
         return Record.builder().recordName(recordName).startTime(startTime).endTime(endTime).duration(duration).member(member).build();

--- a/src/main/java/team9499/commitbody/domain/record/domain/RecordDetails.java
+++ b/src/main/java/team9499/commitbody/domain/record/domain/RecordDetails.java
@@ -1,18 +1,20 @@
 package team9499.commitbody.domain.record.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import team9499.commitbody.domain.exercise.domain.CustomExercise;
 import team9499.commitbody.domain.exercise.domain.Exercise;
+import team9499.commitbody.domain.exercise.domain.enums.ExerciseType;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString(exclude = "record")
 public class RecordDetails {
 
     @Id
@@ -32,6 +34,8 @@ public class RecordDetails {
 
     private Integer sumTimes;       // 기록별 총 수행 시간
 
+    private Integer orders;         // 운동 기록 순서
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "exercise_id",foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Exercise exercise;
@@ -44,14 +48,61 @@ public class RecordDetails {
     @JoinColumn(name = "record_id",foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Record record;
 
-    public static RecordDetails create(Object exercise,Record record){
-        RecordDetailsBuilder builder = RecordDetails.builder();
+    @OneToMany(mappedBy = "recordDetails",cascade = CascadeType.ALL)
+    private List<RecordSets> setsList = new ArrayList<>();
+
+    public static RecordDetails create(Object exercise,Record record,Integer orders){
+        RecordDetailsBuilder builder = RecordDetails.builder().orders(orders);
         if (exercise instanceof Exercise){
             builder.exercise((Exercise) exercise);
         }else
             builder.customExercise((CustomExercise) exercise);
 
         return builder.record(record).build();
+    }
+    public void updateDetailsReps(Integer reps){
+        this.detailsReps = reps;
+    }
+
+    public void updateMaxReps(Integer reps){
+        this.maxReps = reps;
+    }
+
+    public void updateMax1RM(Integer max1Rrm){
+        this.max1RM = max1Rrm;
+    }
+    public void updateDetailsVolume(Integer detailsVolume){
+        this.detailsVolume = detailsVolume;
+    }
+
+    public void updateDetailsTimes(Integer detailsTimes){
+        this.sumTimes = detailsTimes;
+    }
+
+    public void updateOrder(Integer orders){
+        this.orders = orders;
+    }
+
+    public void updateSets(Integer sets){
+        this.detailsSets = sets;
+    }
+
+    public static RecordDetails of(Object exercise,Record record,Integer orders){
+        RecordDetailsBuilder detailsBuilder = RecordDetails.builder().orders(orders).record(record).detailsSets(0);
+        if (exercise instanceof Exercise){
+            ExerciseType exerciseType = ((Exercise) exercise).getExerciseType();
+            if (exerciseType.equals(ExerciseType.REPS_ONLY)){
+                detailsBuilder.maxReps(0).detailsReps(0);
+            }else if (exerciseType.equals(ExerciseType.TIME_ONLY)){
+                detailsBuilder.sumTimes(0);
+            }else{
+                detailsBuilder.maxReps(0).detailsVolume(0).max1RM(0);
+            }
+            detailsBuilder.exercise((Exercise) exercise);
+        }else{
+            detailsBuilder.customExercise((CustomExercise) exercise).maxReps(0).max1RM(0);
+        }
+        return detailsBuilder.build();
     }
 
 }

--- a/src/main/java/team9499/commitbody/domain/record/domain/RecordSets.java
+++ b/src/main/java/team9499/commitbody/domain/record/domain/RecordSets.java
@@ -1,16 +1,14 @@
 package team9499.commitbody.domain.record.domain;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Data
 @Entity
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@ToString(exclude = "recordDetails")
 public class RecordSets {
 
     @Id
@@ -38,5 +36,18 @@ public class RecordSets {
 
     public static RecordSets ofTimes(Integer times,Integer reps, RecordDetails recordDetails) { // 시간만 기록
         return RecordSets.builder().times(times).reps(reps).recordDetails(recordDetails).build();
+    }
+
+    public void updateWeightAndReps(Integer weight, Integer reps){
+        this.weight = weight;
+        this.reps = reps;
+    }
+
+    public void updateReps(Integer reps){
+        this.reps = reps;
+    }
+
+    public void updateTimes(Integer times){
+        this.times = times;
     }
 }

--- a/src/main/java/team9499/commitbody/domain/record/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/request/UpdateRecordRequest.java
@@ -9,19 +9,26 @@ import java.util.List;
 
 
 @Data
+@Schema(description = "기록 수정 Request")
 public class UpdateRecordRequest {
 
+    @Schema(description = "변경할 세트가 존재시 작성")
     private List<RecordUpdateSets> updateSets;      // 세트수 추가
 
+    @Schema(description = "추가할 운동 존재시 작성, [exerciseId,orders,source]필드만 사용 합니다.")
     private List<ExerciseDto> newExercises;     // 운동 추가
 
+    @Schema(description = "삭제할 세트 존재시 setsId 작성")
     private List<Long> deleteSetIds;      // 세트수 삭제
 
+    @Schema(description = "변경할 순서 존재시 detailsId와 변경할 순서 작성")
     private List<ChangeOrders> changeOrders;        // 운동 순서 변경
 
+    @Schema(description = "삭제할 운동 존재시 detailsId 작성")
     private List<Long> deleteDetailsIds;     // 운동 삭제
 
 
+    @Schema(description = "기록 세트 업데이트")
     @Data
     public static class RecordUpdateSets {
         @Schema(description = "상세 루틴 ID")
@@ -34,6 +41,7 @@ public class UpdateRecordRequest {
         private List<RoutineSetsDto> updateSets;
     }
 
+    @Schema(description = "기록 순서 변경")
     @Data
     public static class ChangeOrders{
 

--- a/src/main/java/team9499/commitbody/domain/record/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/request/UpdateRecordRequest.java
@@ -1,0 +1,45 @@
+package team9499.commitbody.domain.record.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import team9499.commitbody.domain.exercise.dto.ExerciseDto;
+import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
+
+import java.util.List;
+
+
+@Data
+public class UpdateRecordRequest {
+
+    private List<RecordUpdateSets> updateSets;      // 세트수 추가
+
+    private List<ExerciseDto> newExercises;     // 운동 추가
+
+    private List<Long> deleteSetIds;      // 세트수 삭제
+
+    private List<ChangeOrders> changeOrders;        // 운동 순서 변경
+
+    private List<Long> deleteDetailsIds;     // 운동 삭제
+
+
+    @Data
+    public static class RecordUpdateSets {
+        @Schema(description = "상세 루틴 ID")
+        private Long recordDetailsId;
+
+        @Schema(description = "새로운 세트")
+        private List<RoutineSetsDto> newSets;
+
+        @Schema(description = "업데이트 세트")
+        private List<RoutineSetsDto> updateSets;
+    }
+
+    @Data
+    public static class ChangeOrders{
+
+        private Long recordDetailsId;
+
+        private Integer orders;
+    }
+    
+}

--- a/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepositoryImpl.java
@@ -45,7 +45,9 @@ public class CustomRecordRepositoryImpl implements CustomRecordRepository{
         List<Tuple> list = jpaQueryFactory.select(record,recordDetails,recordSets).from(record)
                 .join(recordDetails).on(record.id.eq(recordDetails.record.id))
                 .join(recordSets).on(recordSets.recordDetails.id.eq(recordDetails.id))
-                .where(record.id.eq(recordId).and(record.member.id.eq(memberId))).fetch();
+                .where(record.id.eq(recordId).and(record.member.id.eq(memberId)))
+                .orderBy(recordDetails.orders.asc())
+                .fetch();
 
         // Tuple 리스트를 Record를 키로 하고, RecordDetailsResponse 리스트를 값으로 가지는 Map으로 그룹화
         Map<Record, List<RecordDetailsResponse>> groupedDetails = list.stream().collect(Collectors.groupingBy(

--- a/src/main/java/team9499/commitbody/domain/record/repository/RecordRepository.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/RecordRepository.java
@@ -6,4 +6,5 @@ import team9499.commitbody.domain.record.domain.Record;
 
 @Repository
 public interface RecordRepository extends JpaRepository<Record, Long>, CustomRecordRepository {
+    Record findByIdAndMemberId(Long recordId, Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/record/repository/RecordSetsRepository.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/RecordSetsRepository.java
@@ -6,4 +6,6 @@ import team9499.commitbody.domain.record.domain.RecordSets;
 
 @Repository
 public interface RecordSetsRepository extends JpaRepository<RecordSets, Long> {
+    RecordSets findByIdAndRecordDetailsId(Long setsId, Long recordDetailsId);
+    void deleteById(Long setsId);
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
@@ -1,14 +1,19 @@
 package team9499.commitbody.domain.record.service;
 
+import team9499.commitbody.domain.exercise.dto.ExerciseDto;
 import team9499.commitbody.domain.record.dto.RecordDto;
 import team9499.commitbody.domain.record.dto.response.RecordResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static team9499.commitbody.domain.record.dto.request.UpdateRecordRequest.*;
+
 public interface RecordService {
 
     Long saveRecord(Long memberId , String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos);
 
     RecordResponse getRecord(Long recordId,Long memberId);
+
+    void updateRecord(Long memberId, Long recordId, List<RecordUpdateSets> updateSets, List<ExerciseDto> newExercises, List<Long> deleteSets, List<Long> deleteExercises, List<ChangeOrders> changeOrders);
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 public interface RecordService {
 
-    void saveRecord(Long memberId , String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos);
+    Long saveRecord(Long memberId , String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos);
 
     RecordResponse getRecord(Long recordId,Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
@@ -1,12 +1,15 @@
 package team9499.commitbody.domain.record.service;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.domain.Member.repository.MemberRepository;
+import team9499.commitbody.domain.exercise.domain.CustomExercise;
 import team9499.commitbody.domain.exercise.domain.Exercise;
+import team9499.commitbody.domain.exercise.dto.ExerciseDto;
 import team9499.commitbody.domain.exercise.repository.CustomExerciseRepository;
 import team9499.commitbody.domain.exercise.repository.ExerciseRepository;
 import team9499.commitbody.domain.record.domain.Record;
@@ -18,6 +21,9 @@ import team9499.commitbody.domain.record.dto.response.RecordResponse;
 import team9499.commitbody.domain.record.repository.RecordDetailsRepository;
 import team9499.commitbody.domain.record.repository.RecordRepository;
 import team9499.commitbody.domain.record.repository.RecordSetsRepository;
+import team9499.commitbody.domain.routin.dto.RoutineSetsDto;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.ExceptionType;
 import team9499.commitbody.global.Exception.NoSuchException;
 
 import java.time.Duration;
@@ -25,6 +31,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static team9499.commitbody.domain.record.dto.request.UpdateRecordRequest.*;
 import static team9499.commitbody.global.Exception.ExceptionStatus.*;
 import static team9499.commitbody.global.Exception.ExceptionType.*;
 
@@ -40,6 +47,10 @@ public class RecordServiceImpl implements RecordService{
     private final ExerciseRepository exerciseRepository;
     private final CustomExerciseRepository customExerciseRepository;
     private final MemberRepository memberRepository;
+
+    private final EntityManager em;
+
+    private final String DEFAULT ="default";
 
     // TODO: 2024-08-14 리팩토링 필요
     /**
@@ -64,6 +75,7 @@ public class RecordServiceImpl implements RecordService{
         List<RecordSets> recordSets = new ArrayList<>();
         List<RecordDetails> recordDetails = new ArrayList<>();
 
+        int orders = 1;
         for (RecordDto recordDto : recordDtos) {        // 실행한 운동 루틴 순회
             exerciseSize++;
             String source = recordDto.getSource();      // 운동 타입 조회 [default, custom]
@@ -78,7 +90,7 @@ public class RecordServiceImpl implements RecordService{
                 totalMets+= 4;
             }
 
-            RecordDetails recordDetail = RecordDetails.create(exercise,record);       //운동이 적용된 상세 루턴 객체 생성
+            RecordDetails recordDetail = RecordDetails.create(exercise,record,orders++);       //운동이 적용된 상세 루턴 객체 생성
 
             int detailsVolume = 0;      // 상세 운동별 총 볼륨
             int detailsSets = 0;        // 상세 운동별 총 세트
@@ -145,5 +157,184 @@ public class RecordServiceImpl implements RecordService{
     @Override
     public RecordResponse getRecord(Long recordId,Long memberId) {
         return recordRepository.findByRecordId(recordId,memberId);
+    }
+
+    // TODO: 2024-08-24 리팩토링 필요
+    /**
+     * 루틴 완료시 기록된 데이터를 수정하기 위한 메서드
+     * @param memberId 로그인한 사용자 ID
+     * @param recordId 변경할 recordID
+     * @param updateSets  변경및 추가할 세트 클래스
+     * @param newExercises 새롭게 추가할 운동 클래스
+     * @param deleteSets 삭제할 세트 클래스
+     * @param deleteExercises 삭제할 운동 클래스
+     * @param changeOrders 상세 기록 순서를 변경할 클래스
+     */
+    @Override
+    public void updateRecord(Long memberId, Long recordId, List<RecordUpdateSets> updateSets, List<ExerciseDto> newExercises, List<Long> deleteSets, List<Long> deleteExercises, List<ChangeOrders> changeOrders) {
+        Record record = recordRepository.findByIdAndMemberId(recordId, memberId);
+        // 수정 할 세트수가 존재시
+        if (updateSets!=null){
+            for (RecordUpdateSets updateSet : updateSets) {
+                Long recordDetailsId = updateSet.getRecordDetailsId(); // 기록 디테일 ID
+                if (updateSet.getUpdateSets()!=null){       // 수정할 세트수가 있을때
+                    for (RoutineSetsDto set : updateSet.getUpdateSets()) {
+                        RecordSets recordSets = recordSetsRepository.findByIdAndRecordDetailsId(set.getSetsId(), recordDetailsId);
+                        Integer reps = set.getSets();
+                        Integer weight = set.getKg();
+                        Integer times = set.getTimes();
+
+                        if (reps != null && weight != null) {   // 무게 횟수일때
+                            recordSets.updateWeightAndReps(weight, reps);
+                        } else if (times != null) {     // 시간일떄
+                            recordSets.updateTimes(times);
+                        } else {        // 횟수 일때
+                            recordSets.updateReps(reps);
+                        }
+                    }
+                }
+
+                // 새롭게 등록할 세트 수 존재시
+                if (updateSet.getNewSets()!=null){
+                    RecordDetails details = recordDetailsRepository.findById(recordDetailsId).orElseThrow(() -> new NoSuchException(BAD_REQUEST, NO_SUCH_DATA));
+                    for (RoutineSetsDto set : updateSet.getNewSets()) {
+                        recordSets(details,set);        // 새로운 세트 등록
+                    }
+                }
+            }
+        }
+
+        // 추가 할 운동이 존재시
+        if (newExercises!=null){
+            List<RecordDetails> recordDetailsList = new ArrayList<>();
+            for (ExerciseDto newExercise : newExercises) {
+                RecordDetails newRecordDetails;
+                Integer orders = newExercise.getOrders();
+
+                if (newExercise.getSource().equals(DEFAULT)) {      // 일반 운동일 떄
+                    Exercise exercise = getExercise(newExercise.getExerciseId());       // 운동 객체 조회
+                    newRecordDetails = RecordDetails.of(exercise, record,orders);
+                } else {        // 커스텀 운동일 때
+                    CustomExercise customExercise = getCustomExercise(newExercise.getExerciseId());
+                    newRecordDetails = RecordDetails.of(customExercise, record, orders);
+                }
+                // 기록 상세 저장
+                RecordDetails recordDetails = recordDetailsRepository.save(newRecordDetails);
+                // 세트 리스트를 생성
+                List<RecordSets> recordSets = new ArrayList<>();
+                for (RoutineSetsDto set : newExercise.getRoutineSets()) {
+                    recordSets.add(recordSets(recordDetails, set)); // 세트 리스트에 담는다.
+                }
+                recordDetailsList.add(recordDetails);       // 기록 리스트에 담는다.
+                newRecordDetails.setSetsList(recordSets);   // 양방향 세트 매핑에 사용할 리스트를 담는다.
+            }
+            record.setDetailsList(recordDetailsList);      // 양방향 레코드 매핑에 사용할 리스트를 담는다.
+        }
+
+
+        // 삭제 할 세트수가 존재시
+        if (deleteSets !=null){
+            for (Long setsId : deleteSets) {
+                recordSetsRepository.deleteById(setsId);        // 세트 데이터 삭제
+            }
+            em.flush();     // 삭제후 데이터가 영속화 되어 있는 상태이기때문에 삭제된 데이터를 flush 를 통해 적용해준다.
+        }
+
+        // 삭제 할 운동이 존재시
+        if (deleteExercises!=null){
+            for (Long detailsId : deleteExercises) {
+                recordDetailsRepository.deleteById(detailsId); // 상세 기록 삭제
+            }
+            em.flush();     // 삭제후 데이터가 영속화 되어 있는 상태이기때문에 삭제된 데이터를 flush 를 통해 적용해준다.
+        }
+
+
+        // 변경 할 운동 순서가 존재시
+        if (changeOrders != null){
+            for (ChangeOrders changeOrder : changeOrders) {
+                // 변경할 상세 기록 데이터가 있는지 확인후 없으면 400 예외 발생
+                RecordDetails details = recordDetailsRepository.findById(changeOrder.getRecordDetailsId()).orElseThrow(() -> new NoSuchException(BAD_REQUEST, NO_SUCH_DATA));
+                details.updateOrder(changeOrder.getOrders());   // 순서 변경
+            }
+        }
+
+        // 해당 기록에 저장된 상세기록 리스트를 가져온다.
+        List<RecordDetails> detailsList = record.getDetailsList();
+
+        // 상세기록 리스트를 순환한다.
+        for (RecordDetails details : detailsList) {
+            int max1Rm = 0;     // 최대 1RM
+            int count = 0;      // 무게+횟수 기록 운동 갯수
+            int totalTimes = 0;     // 총 운동 시간(시간일때)
+            int maxReps = 0;        // 총 운동 횟수(무게+횟수 , 횟수)
+            int totalVolume = 0;    // 총 볼륨(무게 + 횟수)
+            int totalSets = 0;      // 총 진행한 세트수
+            int totalReps = 0;      // 총 진행한 횟수
+
+            // 세트 리스트를 순환한다.
+            for (RecordSets recordSet :  details.getSetsList()) {
+                Integer weight = recordSet.getWeight();     // 무게
+                Integer reps = recordSet.getReps();         // 횟수
+                Integer times = recordSet.getTimes();       // 시간
+                totalSets++;        // 세트수 증가
+                if (weight!=null&& reps!=null){     // 무게 + 횟수일 떄
+                    max1Rm+= calculate1RM(weight,reps); //1RM 계산
+                    totalVolume += reps*weight; // 총 볼륨 계산
+                    totalReps += reps;      // 횟수 계싼
+                    count++;        // 운동 데이터 수 증가
+                }else if (times!=null){ // 시간일때
+                    totalTimes += times;
+                }else{
+                    maxReps = Math.max(reps,maxReps); // 최대 횟수 갱신
+                    totalReps += reps;
+                }
+            }
+            details.updateSets(totalSets);      // 총 세트수 업데이트
+            if (details.getMax1RM()!=null){     // 무게 + 횟수 일때
+                details.updateMax1RM(max1Rm/count); // 최대 1RM 갱신
+                details.updateDetailsVolume(totalVolume);   // 총 볼륨 갱신
+                details.updateDetailsReps(totalReps);       // 총 횟수 갱신
+            }else if (details.getSumTimes()!=null){     // 시간일 떄
+                details.updateDetailsTimes(totalTimes);     // 총 누적 시간 갱신
+            }else{
+                details.updateMaxReps(maxReps);     // 최대 횟수 갱신
+                details.updateDetailsReps(totalReps);       // 운동 상세 갱신
+            }
+
+        }
+
+    }
+
+    /*
+    상세 운동의 대한 횟수를 새롭게 저장하는 메서드
+     */
+    private RecordSets recordSets(RecordDetails recordDetail, RoutineSetsDto newSet) {
+        Integer sets = newSet.getSets();        // 세트수
+        Integer kg = newSet.getKg();            // kg
+        Integer times = newSet.getTimes();      // 시간수
+        RecordSets recordSets;
+        if (sets != null & kg != null) {        // 무게-세트 기준
+            recordSets = RecordSets.ofWeightAndSets(kg, sets, recordDetail);
+        } else if (times != null) {             // 시간 기준
+            recordSets = RecordSets.ofTimes(times, sets,recordDetail);
+        } else                                  // 세트 기준
+            recordSets = RecordSets.ofSets(sets, recordDetail);
+        return recordSetsRepository.save(recordSets);
+    }
+
+
+    /*
+    최대 1RM 무게를 계산하는 메서드
+     */
+    private int calculate1RM(Integer weight, Integer reps) {
+        return Math.round(weight * (1 + 0.03333f * reps));
+    }
+
+    private CustomExercise getCustomExercise(Long exerciseId) {
+        return customExerciseRepository.findById(exerciseId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+    }
+
+    private Exercise getExercise(Long exerciseId) {
+        return exerciseRepository.findById(exerciseId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
     }
 }

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordServiceImpl.java
@@ -50,7 +50,7 @@ public class RecordServiceImpl implements RecordService{
      * @param endTime 마무리 시간
      */
     @Override
-    public void saveRecord(Long memberId, String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos) {
+    public Long saveRecord(Long memberId, String recordName, LocalDateTime startTime, LocalDateTime endTime, List<RecordDto> recordDtos) {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchException(BAD_REQUEST, No_SUCH_MEMBER));
         int totalVolume = 0;        // 투틴 총 수행 볼륨
         int totalSets = 0;          // 루틴 총 진행 세트
@@ -135,9 +135,10 @@ public class RecordServiceImpl implements RecordService{
         record.setRecordVolume(totalVolume);;
         record.setRecordCalorie(totalCalorie);
 
-        recordRepository.save(record);
+        Record save = recordRepository.save(record);
         recordDetailsRepository.saveAll(recordDetails);
         recordSetsRepository.saveAll(recordSets);
+        return save.getId();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 개요
- 루틴 완료시 기록된 recordId를 반환하도록 리팩토링
- 기록 수정시 운동 순서, 운동 추가, 운동삭제, 세트 삭제/추가/업데이트의 기능을 사용하도록 구현
- Swagger 문서 작성
- record 관련 양방향 매핑 설정

Resolves: #49 
Ref : #50 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).