### PR TITLE
기록 조회 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -9,17 +9,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.record.dto.request.RecordRequest;
 import team9499.commitbody.domain.record.dto.request.UpdateRecordRequest;
+import team9499.commitbody.domain.record.dto.response.RecordMonthResponse;
 import team9499.commitbody.domain.record.dto.response.RecordResponse;
 import team9499.commitbody.domain.record.repository.RecordRepository;
 import team9499.commitbody.domain.record.service.RecordService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
 import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
+
+import java.time.LocalDateTime;
 
 @Tag(name = "기록",description = "운동 기록이 관련 API")
 @RestController
@@ -109,6 +114,15 @@ public class RecordController {
         Long memberId = getMemberId(principalDetails);
         recordService.deleteRecord(memberId,recordId);
         return ResponseEntity.ok(new SuccessResponse<>(true,"삭제 성공"));
+    }
+
+    @GetMapping("/record")
+    public ResponseEntity<?> get(@RequestParam(value = "lastTime",required = false) LocalDateTime lastTime,
+                                 @PageableDefault(size = 10) Pageable pageable,
+                                 @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = getMemberId(principalDetails);
+        RecordMonthResponse recordForMember = recordService.getRecordForMember(memberId,lastTime,pageable);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",recordForMember));
     }
 
 

--- a/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
+++ b/src/main/java/team9499/commitbody/domain/record/controller/RecordController.java
@@ -57,7 +57,7 @@ public class RecordController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"루틴 성공",recordId));
     }
 
-    @Operation(summary = "기록 조회", description = "사용자가 완료한 기록의 대한 정보를 조회합니다.")
+    @Operation(summary = "기록 상세 조회", description = "사용자가 완료한 기록의 대한 상세 정보를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                     examples = @ExampleObject(value = "{\"success\":true,\"message\":\"조회 성공\",\"data\":{\"recordId\":1,\"recordName\":\"나의 첫 번째 기록\",\"startDate\":\"2024.08.14.(수)\",\"durationTime\":\"6:46~8:46\",\"duration\":120,\"recordVolume\":85,\"recordSets\":11,\"recordCalorie\":414,\"details\":[{\"recordDetailId\":1,\"exerciseId\":1,\"gifUrl\":\"https://example.com\",\"detailsReps\":12,\"detailsSets\":2,\"maxReps\":7,\"sets\":[{\"setId\":191,\"reps\":6},{\"setId\":192,\"reps\":7}]}]}}"))),
@@ -116,15 +116,22 @@ public class RecordController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"삭제 성공"));
     }
 
+    @Operation(summary = "기록 조회", description = "사용자가 진행한 기록의 대해 모두 조회합니다. Default : size - 10, lastTime은 다음페이지 존재시 마지막 시간을 보냅니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"조회 성공\",\"data\":{\"dayRecordCount\":{\"1\":{\"day\":\"2024.08.01.(목)\",\"recordDays\":[{\"recordId\":56,\"recordName\":\"테스트\",\"durationTime\":\"2024.08.01.(목) · 18:37~20:37\"}]},\"3\":{\"day\":\"2024.08.03.(토)\",\"recordDays\":[{\"recordId\":58,\"recordName\":\"테스트\",\"durationTime\":\"2024.08.03.(토) · 18:37~20:37\"}]}},\"recordPage\":{\"hasNext\":false,\"records\":[{\"recordId\":57,\"recordName\":\"테스트\",\"durationTime\":\"2024.08.01.(목) · 18:37~20:37\",\"lastTime\":\"2024-08-01T20:37:32.71\"}]}}}"))),
+            @ApiResponse(responseCode = "400", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/record")
     public ResponseEntity<?> get(@RequestParam(value = "lastTime",required = false) LocalDateTime lastTime,
-                                 @PageableDefault(size = 10) Pageable pageable,
+                                 @Parameter(example = "{\"size\":10}")@PageableDefault(size = 10) Pageable pageable,
                                  @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = getMemberId(principalDetails);
         RecordMonthResponse recordForMember = recordService.getRecordForMember(memberId,lastTime,pageable);
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",recordForMember));
     }
-
 
     private static Long getMemberId(PrincipalDetails principalDetails) {
         Long memberId = principalDetails.getMember().getId();

--- a/src/main/java/team9499/commitbody/domain/record/domain/Record.java
+++ b/src/main/java/team9499/commitbody/domain/record/domain/Record.java
@@ -11,6 +11,9 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@Table(indexes = {
+        @Index(name = "idx_member_id_end_time",columnList = "member_id, end_time ASC")
+})
 @Data
 @Entity
 @Builder
@@ -38,7 +41,7 @@ public class Record {
     private Integer duration;           // 진행시간
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id",foreignKey =  @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private Member member;
 
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL)

--- a/src/main/java/team9499/commitbody/domain/record/dto/RecordDto.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/RecordDto.java
@@ -1,13 +1,23 @@
 package team9499.commitbody.domain.record.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
 @Schema(name = "기록Dto")
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecordDto {
+
+    private Long recordId;
+
+    private LocalDateTime endTime;
+
+    private String recordName;
+
 
     @Schema(description = "운동 ID")
     private Long exerciseId;

--- a/src/main/java/team9499/commitbody/domain/record/dto/response/RecordMonthResponse.java
+++ b/src/main/java/team9499/commitbody/domain/record/dto/response/RecordMonthResponse.java
@@ -1,0 +1,53 @@
+package team9499.commitbody.domain.record.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecordMonthResponse {
+
+    private Map<String,RecordData> dayRecordCount;        // 일별 진행 횟수
+
+    private RecordPage recordPage;
+
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecordPage {
+        private boolean hasNext;
+        private List<RecordDay> records;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RecordData{
+        private String day;
+        private List<RecordDay> recordDays;
+    }
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class RecordDay {
+        private Long recordId;
+        private String recordName;  // 기록명
+        private String durationTime;    // 진행시간
+        private LocalDateTime lastTime; // 마지막 타임
+
+        public RecordDay(Long recordId, String recordName, String durationTime) {
+            this.recordId = recordId;
+            this.recordName = recordName;
+            this.durationTime = durationTime;
+        }
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepository.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepository.java
@@ -1,10 +1,20 @@
 package team9499.commitbody.domain.record.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import team9499.commitbody.domain.record.dto.response.RecordMonthResponse;
 import team9499.commitbody.domain.record.dto.response.RecordResponse;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static team9499.commitbody.domain.record.dto.response.RecordMonthResponse.*;
 
 public interface CustomRecordRepository {
 
     RecordResponse findByRecordId(Long recordId, Long memberId);
     void deleteCustomExercise(Long customExerciseId);
     void deleteRecord(Long recordId, Long memberId);
+    Map<String, RecordData> getRecordCountAdnDataForMonth(Long memberId);
+    Slice<RecordDay> getRecordPage(Long memberId, LocalDateTime lastTime, Pageable pageable);
 }

--- a/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/record/repository/CustomRecordRepositoryImpl.java
@@ -1,10 +1,14 @@
 package team9499.commitbody.domain.record.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 import team9499.commitbody.domain.exercise.domain.CustomExercise;
 import team9499.commitbody.domain.exercise.domain.Exercise;
@@ -25,6 +29,7 @@ import java.util.stream.Collectors;
 import static team9499.commitbody.domain.record.domain.QRecord.*;
 import static team9499.commitbody.domain.record.domain.QRecordDetails.*;
 import static team9499.commitbody.domain.record.domain.QRecordSets.*;
+import static team9499.commitbody.domain.record.dto.response.RecordMonthResponse.*;
 
 @Slf4j
 @Repository
@@ -154,6 +159,102 @@ public class CustomRecordRepositoryImpl implements CustomRecordRepository{
             jpaQueryFactory.delete(record)
                     .where(record.id.eq(recordId).and(record.member.id.eq(memberId)))
                     .execute();
+    }
+
+    /**
+     * 기록페이지에서 해당 달의 일별로 진행한 기록을 조회
+     * @param memberId  로그인한 사용자 아이디
+     */
+    @Override
+    public Map<String, RecordData> getRecordCountAdnDataForMonth(Long memberId){
+        // 현재 시간으로부터 해당 달 조회
+        Result result = getResult();
+
+        List<Record> records = jpaQueryFactory.selectFrom(record)
+                .where(record.member.id.eq(memberId).and(record.endTime.between(result.startOfDay(), result.lastOfDay())))
+                .orderBy(record.endTime.asc()).fetch();
+
+        Map<String, RecordData> dayRecordCount = new LinkedHashMap<>();
+        for (Record record : records) {
+            String day = String.valueOf(record.getEndTime().getDayOfMonth());
+
+            // RecordDay 객체 생성
+            RecordDay recordDay = new RecordDay(record.getId(), record.getRecordName(),
+                    converterTime(record) + " · " + converterDurationTime(record));
+
+            // 해당 날짜에 대한 RecordData 객체를 가져옴
+            RecordData recordData = dayRecordCount.getOrDefault(day, new RecordData());
+
+            // 기존의 RecordDay 리스트를 가져오거나, 없으면 새로 생성
+            List<RecordDay> recordDays = recordData.getRecordDays();
+            if (recordDays == null) {
+                recordDays = new ArrayList<>();
+            }
+
+            // 새로 생성한 RecordDay를 리스트에 추가
+            recordDays.add(recordDay);
+
+            // RecordData의 필드 업데이트
+            recordData.setDay(converterTime(record)); // 날짜가 여러 개일 경우, 이 줄이 여러 번 덮어써지므로 조심
+            recordData.setRecordDays(recordDays);
+
+            // dayRecordCount 맵에 업데이트된 RecordData를 다시 저장
+            dayRecordCount.put(day, recordData);
+        }
+        return dayRecordCount;
+    }
+
+    /**
+     * 해당달의 진행만 모든 기록을 무한 스크롤 조회
+     * @param memberId  로그인한 사용자 ID
+     * @param lastTime  마지막 시간
+     * @param pageable  페이징 정보
+     */
+    @Override
+    public Slice<RecordDay> getRecordPage(Long memberId,LocalDateTime lastTime,Pageable pageable){
+        // 마지막 시간으로 lastTime 보다 작은 시간의 값을 조회
+        BooleanBuilder builder = new BooleanBuilder();
+        if (lastTime!=null){
+            builder.and(record.endTime.lt(lastTime));
+        }
+        Result result = getResult();
+
+        List<Record> records = jpaQueryFactory.selectFrom(record)
+                .where(builder,record.member.id.eq(memberId).and(record.endTime.between(result.startOfDay(), result.lastOfDay())))
+                .limit(pageable.getPageSize()+1)
+                .orderBy(record.endTime.desc()).fetch();
+
+        // 다음 페이지 존재 여부
+        boolean hasNext = false;
+        if (records.size() >pageable.getPageSize()){
+            records.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        
+        // 데이터 변환
+        List<RecordDay> recordData = records.stream()
+                .map(record ->
+                        new RecordDay(record.getId(),record.getRecordName(),
+                                converterTime(record)+" · "+converterDurationTime(record),record.getEndTime())).collect(Collectors.toList());
+
+        return new SliceImpl<>(recordData, pageable, hasNext);
+    }
+
+    /*
+    현재 일 기준으로 해당달의 1일부터 마지막 일의 시간을 구하는 메서드
+     */
+    private static Result getResult() {
+        LocalDate now = LocalDate.now();
+        LocalDateTime startOfDay = now.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime lastOfDay = now.withDayOfMonth(now.lengthOfMonth()).atStartOfDay();
+        Result result = new Result(startOfDay, lastOfDay);
+        return result;
+    }
+
+    /*
+    레코드 생성
+     */
+    private record Result(LocalDateTime startOfDay, LocalDateTime lastOfDay) {
     }
 
     /*

--- a/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
+++ b/src/main/java/team9499/commitbody/domain/record/service/RecordService.java
@@ -1,7 +1,9 @@
 package team9499.commitbody.domain.record.service;
 
+import org.springframework.data.domain.Pageable;
 import team9499.commitbody.domain.exercise.dto.ExerciseDto;
 import team9499.commitbody.domain.record.dto.RecordDto;
+import team9499.commitbody.domain.record.dto.response.RecordMonthResponse;
 import team9499.commitbody.domain.record.dto.response.RecordResponse;
 
 import java.time.LocalDateTime;
@@ -18,4 +20,6 @@ public interface RecordService {
     void updateRecord(Long memberId, Long recordId, List<RecordUpdateSets> updateSets, List<ExerciseDto> newExercises, List<Long> deleteSets, List<Long> deleteExercises, List<ChangeOrders> changeOrders);
 
     void deleteRecord(Long memberId, Long recordId);
+
+    RecordMonthResponse getRecordForMember(Long memberId,LocalDateTime lastTime, Pageable pageable);
 }


### PR DESCRIPTION
## 개요
- 사용자가 기록한 모든 기록을 조회하는 API 구현
- 해당 달을 계산후 일별로 저장된 운동 기록을 조회하며, 해당달의 기록된 모든 기록을 무한 스크롤 방식으로 구현
- Record의 member의 외래키를 생성하지 않도록 코드 작성

Resolves: #55 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).