### PR TITLE
팔로워 API 구현 및 사용자 도메인 수정

### DIFF
--- a/src/main/java/team9499/commitbody/domain/Member/domain/AccountStatus.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/AccountStatus.java
@@ -1,0 +1,6 @@
+package team9499.commitbody.domain.Member.domain;
+
+public enum AccountStatus {
+    PUBLIC, // 공개
+    PRIVATE // 비공개
+}

--- a/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
@@ -22,6 +22,8 @@ public class Member extends BaseTime {
 
     private String socialId;    // 소셜로그인 사용자 ID
 
+    private String profile; // 사용자 프로필
+
     private String nickname;    // 닉네임
 
     private float height;      // 키
@@ -49,8 +51,11 @@ public class Member extends BaseTime {
 
     private boolean isUserDeactivated; //알림유무(true : 알림 받기, false : 알림 안받기)
 
-    public static Member createSocialId(String socialId,LoginType loginType){
-        return Member.builder().socialId(socialId).loginType(loginType).build();
+    @Enumerated(EnumType.STRING)
+    private AccountStatus accountStatus;        // 계정 상태 - PUBLIC : 공개(기본 값) , PRIVATE : 비공개
+
+    public static Member createSocialId(String socialId,LoginType loginType,String profile){
+        return Member.builder().socialId(socialId).loginType(loginType).profile(profile).accountStatus(AccountStatus.PUBLIC).build();
     }
 
     public void createAdditionalInfoNotNull(String nickName, Gender gender, LocalDate birthday, float height, float weight,float boneMineralDensity, float bodyFatPercentage){

--- a/src/main/java/team9499/commitbody/domain/follow/controller/FollowController.java
+++ b/src/main/java/team9499/commitbody/domain/follow/controller/FollowController.java
@@ -1,0 +1,54 @@
+package team9499.commitbody.domain.follow.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team9499.commitbody.domain.follow.dto.request.FollowRequest;
+import team9499.commitbody.domain.follow.dto.response.FollowResponse;
+import team9499.commitbody.domain.follow.service.FollowService;
+import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.payload.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/follow")
+    public ResponseEntity<?> requestFollow(@RequestBody FollowRequest followRequest,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long followerId = getMember(principalDetails);
+        String followStatus = followService.follow(followerId, followRequest.getFollowId(), followRequest.getType());
+        return ResponseEntity.ok(new SuccessResponse<>(true,followStatus));
+    }
+    @GetMapping("/followers")
+    public ResponseEntity<?> getFollowers(@RequestParam(value = "lastId",required = false) Long lastId,
+                                          @RequestParam(value = "nickname",required = false) String nickname,
+                                          @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                          @PageableDefault Pageable pageable){
+
+        Long followId = getMember(principalDetails);
+        FollowResponse followers = followService.getFollowers(followId,nickname,lastId,pageable);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",followers));
+    }
+
+    @GetMapping("/followings")
+    public ResponseEntity<?> getFollows(@RequestParam(value = "lastId",required = false) Long lastId,
+                                        @RequestParam(value = "nickname",required = false) String nickname,
+                                        @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                        @PageableDefault Pageable pageable){
+        Long followId = getMember(principalDetails);
+        FollowResponse followings = followService.getFollowings(followId, nickname, lastId, pageable);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공", followings));
+    }
+
+    private static Long getMember(PrincipalDetails principalDetails) {
+        Long followId = principalDetails.getMember().getId();
+        return followId;
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/follow/controller/FollowController.java
+++ b/src/main/java/team9499/commitbody/domain/follow/controller/FollowController.java
@@ -1,5 +1,13 @@
 package team9499.commitbody.domain.follow.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -10,8 +18,10 @@ import team9499.commitbody.domain.follow.dto.request.FollowRequest;
 import team9499.commitbody.domain.follow.dto.response.FollowResponse;
 import team9499.commitbody.domain.follow.service.FollowService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
 
+@Tag(name = "팔로워",description = "팔로워 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
@@ -19,6 +29,18 @@ public class FollowController {
 
     private final FollowService followService;
 
+    @Operation(summary = "팔로워", description = "하나의 API를 통해 팔로워/팔로잉등 요청을 수행합니다.type의 팔로우요청 , 맞팔로우시 FOLLOW, 언팔시및 팔로우 취소시 UNFOLLOW를 작성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청 성공시 - 각 요청 응답에 맞게 [맞팔로우,언팔로우,팔로우 요청,팔로우 취소]을 반환 합니다.", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"맞팔로우\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 반복 요청시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"이미 처리된 요청입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 사용자 존재하지 않을시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @PostMapping("/follow")
     public ResponseEntity<?> requestFollow(@RequestBody FollowRequest followRequest,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails){
@@ -26,22 +48,39 @@ public class FollowController {
         String followStatus = followService.follow(followerId, followRequest.getFollowId(), followRequest.getType());
         return ResponseEntity.ok(new SuccessResponse<>(true,followStatus));
     }
+
+    @Operation(summary = "팔로워 목록(무한 스크롤)", description = "팔로워 목록을 조회하며, 사용자 닉네임을통해 나를 팔로워한 사용자를 찾을수 있습니다.[2글자이상]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공 - mutualFollow - ture 맞팔로워,  mutualFollow - false 팔로워 ", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"hasNext\": false, \"follows\": [{\"followId\": 1, \"memberId\": 1, \"nickname\": \"닉네임\", \"profile\": \"http://www.example.com\", \"mutualFollow\": true}]}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/followers")
     public ResponseEntity<?> getFollowers(@RequestParam(value = "lastId",required = false) Long lastId,
                                           @RequestParam(value = "nickname",required = false) String nickname,
                                           @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                          @PageableDefault Pageable pageable){
+                                          @Parameter(example = "{\"size\":10}") @PageableDefault Pageable pageable){
 
         Long followId = getMember(principalDetails);
         FollowResponse followers = followService.getFollowers(followId,nickname,lastId,pageable);
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",followers));
     }
 
+    @Operation(summary = "팔로잉 목록(무한 스크롤)", description = "팔로잉 목록을 조회하며, 사용자 닉네임을통해 내가 팔로잉한 사용자를 찾을수 있습니다.[2글자이상]")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"hasNext\": false, \"follows\": [{\"followId\": 1, \"memberId\": 1, \"nickname\": \"닉네임\", \"profile\": \"http://www.example.com\"}]}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/followings")
     public ResponseEntity<?> getFollows(@RequestParam(value = "lastId",required = false) Long lastId,
                                         @RequestParam(value = "nickname",required = false) String nickname,
                                         @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                        @PageableDefault Pageable pageable){
+                                        @Parameter(example = "{\"size\":10}") @PageableDefault Pageable pageable){
         Long followId = getMember(principalDetails);
         FollowResponse followings = followService.getFollowings(followId, nickname, lastId, pageable);
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공", followings));

--- a/src/main/java/team9499/commitbody/domain/follow/domain/Follow.java
+++ b/src/main/java/team9499/commitbody/domain/follow/domain/Follow.java
@@ -1,0 +1,43 @@
+package team9499.commitbody.domain.follow.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import team9499.commitbody.domain.Member.domain.Member;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@Builder
+@Data
+@ToString(exclude = {"follower", "following"})
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id") // follower를 위한 컬럼
+    private Member follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id") // following을 위한 컬럼
+    private Member following;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status",length = 20)
+    private FollowStatus status;
+
+    public static Follow create(Member follower, Member following,FollowType type){
+        if (type.equals(FollowType.FOLLOWING)){
+            return Follow.builder().follower(follower).following(following).status(FollowStatus.FOLLOWING).build();
+        }else{
+            return Follow.builder().follower(follower).following(following).status(FollowStatus.REQUEST).build();
+        }
+    }
+
+    public void updateFollowStatus(FollowStatus followStatus){
+        this.status = followStatus;
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/follow/domain/FollowStatus.java
+++ b/src/main/java/team9499/commitbody/domain/follow/domain/FollowStatus.java
@@ -1,0 +1,10 @@
+package team9499.commitbody.domain.follow.domain;
+
+public enum FollowStatus {
+    FOLLOWING, // 팔로잉
+    UNFOLLOW,   // 언팔로우
+    REQUEST,  // 팔로우 요청 상태
+    MUTUAL_FOLLOW, //맞 팔로잉 
+    CANCEL,         // 팔로우 취소
+    BLOCK   // 차단된 상태
+}

--- a/src/main/java/team9499/commitbody/domain/follow/domain/FollowType.java
+++ b/src/main/java/team9499/commitbody/domain/follow/domain/FollowType.java
@@ -1,0 +1,9 @@
+package team9499.commitbody.domain.follow.domain;
+
+public enum FollowType {
+    FOLLOW,
+    FOLLOWING,
+    CANCEL,
+    MUTUAL_FOLLOW,
+    UNFOLLOW;
+}

--- a/src/main/java/team9499/commitbody/domain/follow/dto/FollowerDto.java
+++ b/src/main/java/team9499/commitbody/domain/follow/dto/FollowerDto.java
@@ -1,0 +1,21 @@
+package team9499.commitbody.domain.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowerDto {
+
+    private Long followId;
+
+    private Long memberId;
+
+    private String nickname;
+
+    private String profile;
+
+    private boolean mutualFollow;    //맞팔로우 상태
+}

--- a/src/main/java/team9499/commitbody/domain/follow/dto/FollowingDto.java
+++ b/src/main/java/team9499/commitbody/domain/follow/dto/FollowingDto.java
@@ -1,0 +1,20 @@
+package team9499.commitbody.domain.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowingDto {
+
+    private Long followId;
+
+    private Long memberId;
+
+    private String nickname;
+
+    private String profile;
+
+}

--- a/src/main/java/team9499/commitbody/domain/follow/dto/request/FollowRequest.java
+++ b/src/main/java/team9499/commitbody/domain/follow/dto/request/FollowRequest.java
@@ -1,0 +1,12 @@
+package team9499.commitbody.domain.follow.dto.request;
+
+import lombok.Data;
+import team9499.commitbody.domain.follow.domain.FollowType;
+
+@Data
+public class FollowRequest {
+
+    private Long followId;
+
+    private FollowType type;
+}

--- a/src/main/java/team9499/commitbody/domain/follow/dto/response/FollowResponse.java
+++ b/src/main/java/team9499/commitbody/domain/follow/dto/response/FollowResponse.java
@@ -1,0 +1,16 @@
+package team9499.commitbody.domain.follow.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class FollowResponse<T> {
+
+    private boolean hasNext;
+    private List<T> follows;
+}

--- a/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepository.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepository.java
@@ -1,0 +1,15 @@
+package team9499.commitbody.domain.follow.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import team9499.commitbody.domain.follow.dto.FollowerDto;
+import team9499.commitbody.domain.follow.dto.FollowingDto;
+
+import java.util.List;
+
+public interface CustomFollowRepository {
+
+    Slice<FollowingDto> getAllFollowings(Long followerId, String nickName, Long lastId, Pageable pageable);
+
+    Slice<FollowerDto> getAllFollowers(Long followerId,String nickName,Long lastId, Pageable pageable);
+}

--- a/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepositoryImpl.java
@@ -1,0 +1,111 @@
+package team9499.commitbody.domain.follow.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.domain.follow.domain.Follow;
+import team9499.commitbody.domain.follow.domain.FollowStatus;
+import team9499.commitbody.domain.follow.dto.FollowerDto;
+import team9499.commitbody.domain.follow.dto.FollowingDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static team9499.commitbody.domain.Member.domain.QMember.*;
+import static team9499.commitbody.domain.follow.domain.QFollow.*;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomFollowRepositoryImpl implements CustomFollowRepository{
+
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    private final String FULL_TEXT_INDEX ="function('match',{0},{1})";
+
+    /**
+     * 해당 사용자가 팔로잉한 사용자의 목록을 조회합니다.
+     * @param followerId 조회할 사용자
+     */
+    @Override
+    public Slice<FollowingDto> getAllFollowings(Long followerId, String nickName,Long lastId, Pageable pageable) {
+        BooleanBuilder builder = lastIdBuilder(lastId);
+        nicknameBuilder(nickName, builder);
+
+        List<Follow> followList = jpaQueryFactory.select(follow)
+                .from(follow)
+                .join(member).on(member.id.eq(follow.following.id))
+                .where(builder,follow.follower.id.eq(followerId).and(follow.status.eq(FollowStatus.FOLLOWING).or(follow.status.eq(FollowStatus.MUTUAL_FOLLOW))))
+                .limit(pageable.getPageSize()+1)
+                .orderBy(follow.id.asc())
+                .fetch();
+
+        List<FollowingDto> followingDtoList = followList.stream()
+                .map(follow -> new FollowingDto(
+                        follow.getId(),follow.getFollowing().getId(), follow.getFollowing().getNickname(),follow.getFollowing().getProfile())
+                )
+                .collect(Collectors.toList());
+
+        boolean hasNext = false;
+        if (followingDtoList.size() > pageable.getPageSize()){
+            hasNext = true;
+            followingDtoList.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(followingDtoList,pageable,hasNext);
+    }
+
+    /**
+     * 해당 사용자를 팔로워 하는 목록을 조회
+     * @param followerId 조회할 사용자
+     */
+    @Override
+    public Slice<FollowerDto> getAllFollowers(Long followerId, String nickName, Long lastId, Pageable pageable) {
+        BooleanBuilder builder = lastIdBuilder(lastId);
+        nicknameBuilder(nickName,builder);
+
+        List<Follow> followList = jpaQueryFactory.select(follow)
+                .from(follow)
+                .join(member).on(member.id.eq(follow.follower.id))  // 올바른 조인 조건
+                .where(builder,follow.following.id.eq(followerId).and(follow.status.eq(FollowStatus.FOLLOWING).or(follow.status.eq(FollowStatus.MUTUAL_FOLLOW))))  // 올바른 조건
+                .orderBy(follow.id.asc())
+                .fetch();
+
+        List<FollowerDto> followerDtoList = followList.stream()
+                .map(follow -> new FollowerDto(
+                        follow.getId(), follow.getFollower().getId(), follow.getFollower().getNickname(), follow.getFollower().getProfile(),checkFollow(follow.getStatus()))
+                )
+                .collect(Collectors.toList());
+
+        boolean hasNext = false;
+        if (followerDtoList.size() > pageable.getPageSize()){
+            hasNext= true;
+            followerDtoList.remove(pageable.getPageSize());
+        }
+        return new SliceImpl<>(followerDtoList,pageable,hasNext);
+    }
+
+    private static boolean checkFollow(FollowStatus followStatus){
+        return followStatus.equals(FollowStatus.FOLLOWING) ? false : true;
+    }
+
+    private static BooleanBuilder lastIdBuilder(Long lastId) {
+        BooleanBuilder builder = new BooleanBuilder();
+        if (lastId !=null){
+            builder.and(follow.id.gt(lastId));
+        }
+        return builder;
+    }
+    private void nicknameBuilder(String nickName, BooleanBuilder builder) {
+        if (nickName != null) {
+            NumberTemplate<Double> doubleNumberTemplate = Expressions.numberTemplate(Double.class,
+                    FULL_TEXT_INDEX, member.nickname,"+"+ nickName +"+");
+            builder.and(doubleNumberTemplate.gt(0));
+        }
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/FollowRepository.java
@@ -1,0 +1,26 @@
+package team9499.commitbody.domain.follow.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.domain.follow.domain.Follow;
+
+import java.util.Optional;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long>, CustomFollowRepository {
+
+    @Query("select f from Follow f where f.follower.id = :followerId and f.following.id = :followingId and f.status = 'REQUEST'")
+    Optional<Follow> findByFollowReqeust(@Param("followerId") Long followerId, @Param("followingId") Long followingId);
+
+    @Query("select f from Follow f where f.follower.id = :followerId and f.following.id = :followingId and f.status = 'FOLLOWING'")
+    Optional<Follow> findByFollowerReqeust(@Param("followerId") Long followerId, @Param("followingId") Long followingId);
+
+    boolean existsByFollowerIdAndFollowingId(Long followerId,Long followingId);
+
+    Optional<Follow> findByFollowerIdAndFollowingId(Long followerId,Long followingId);
+
+    void deleteByFollowerIdAndFollowingId(Long followerId,Long followingId);
+
+}

--- a/src/main/java/team9499/commitbody/domain/follow/service/FollowService.java
+++ b/src/main/java/team9499/commitbody/domain/follow/service/FollowService.java
@@ -1,0 +1,14 @@
+package team9499.commitbody.domain.follow.service;
+
+import org.springframework.data.domain.Pageable;
+import team9499.commitbody.domain.follow.domain.FollowType;
+import team9499.commitbody.domain.follow.dto.response.FollowResponse;
+
+public interface FollowService {
+
+    String follow(Long followerId, Long followingId, FollowType type);
+
+    FollowResponse getFollowers(Long followingId, String nickName, Long lastId, Pageable pageable);
+
+    FollowResponse getFollowings(Long followerId,String nickName, Long lastId, Pageable pageable);
+}

--- a/src/main/java/team9499/commitbody/domain/follow/service/FollowServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/follow/service/FollowServiceImpl.java
@@ -1,0 +1,182 @@
+package team9499.commitbody.domain.follow.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.domain.Member.repository.MemberRepository;
+import team9499.commitbody.domain.follow.domain.Follow;
+import team9499.commitbody.domain.follow.domain.FollowStatus;
+import team9499.commitbody.domain.follow.domain.FollowType;
+import team9499.commitbody.domain.follow.dto.FollowerDto;
+import team9499.commitbody.domain.follow.dto.FollowingDto;
+import team9499.commitbody.domain.follow.dto.response.FollowResponse;
+import team9499.commitbody.domain.follow.repository.FollowRepository;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.Exception.InvalidUsageException;
+import team9499.commitbody.global.Exception.NoSuchException;
+import team9499.commitbody.global.redis.RedisService;
+
+import java.time.Duration;
+import java.util.Optional;
+
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowServiceImpl implements FollowService{
+
+    private final FollowRepository followRepository;
+    private final RedisService redisService;
+    private final MemberRepository memberRepository;
+
+
+    private final String TO ="to";
+    private final String MUTUAL_FOLLOW = "맞팔로우";
+    private final String UNFOLLOW = "언팔로우";
+    private final String CANCEL_FOLLOW = "팔로우 취소";
+    private final String REQUEST_FOLLOW = "팔로우 요청";
+
+
+    /**
+     * 팔로워 메서드
+     * 1. 팔로워 요청
+     * 2. 팔로잉 요청
+     * 3. 맞팔로잉
+     * 4. 언팔로잉
+     * 5. 팔로워 취소
+     * 하나의 메서드를 통해 5가지 기능을 동적으로 작동하도록 구현
+     * @param followerId 팔로워 기능을 요청 사용자
+     * @param followingId   팔로워 기능을 받는 사용자
+     * @param type  FOLLOW,UNFOLLOW 을 통해 언팔, 팔로워 구분
+     * @return  (맞팔로우, 언팔로우, 팔로우 취소, 팔로우 요청) 요청 타입에 맞게 반환 
+     */
+    @Override
+    public String follow(Long followerId, Long followingId, FollowType type) {
+
+        String status = "";
+        Member follower = getRedisMember(followerId);
+        Member following = getRedisMember(followingId);
+
+        Follow toFollow = Follow.create(follower, following, FollowType.FOLLOWING);
+        Follow fromFollow = Follow.create(following, follower, FollowType.FOLLOW);
+
+        // 'FOLLOWING' 관계 처리
+        status = handleFollowRelationship(followerId, followingId, toFollow,type,TO);
+        // 'FOLLOW' 관계 처리
+        handleFollowRelationship(followingId, followerId, fromFollow, type, "from");
+
+        return status;
+    }
+
+    /**
+     * 팔로워 목록 조회
+     * @param followingId  조회할 팔로잉 ID
+     * @param nickName  검색할 사용자 명(required : false)
+     * @param lastId    마지막 팔로워 ID 값(required : false)
+     * @param pageable 페이징 정보
+     * @return 검색한 데이터를 FollowResponse 객체러로 매핑후 반환
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public FollowResponse getFollowers(Long followingId, String nickName,Long lastId, Pageable pageable) {
+        Slice<FollowerDto> allFollowers = followRepository.getAllFollowers(followingId, nickName,lastId, pageable);
+        return new FollowResponse(allFollowers.hasNext(),allFollowers.getContent());
+    }
+
+    /**
+     * 팔로워 목록 조회
+     * @param followerId 조회할 팔로워 ID
+     * @param nickName  검색할 사용자 닉네임(required : false)
+     * @param lastId    마지막 팔로워 ID 값(required : false)
+     * @param pageable  페이징 정보
+     * @return 검색한 데이터를 FollowResponse 객체러로 매핑후 반환
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public FollowResponse getFollowings(Long followerId,String nickName,Long lastId, Pageable pageable) {
+        Slice<FollowingDto> allFollowings = followRepository.getAllFollowings(followerId, nickName, lastId, pageable);
+        return new FollowResponse(allFollowings.hasNext(),allFollowings.getContent());
+    }
+
+    /*
+    사용자 정보를 조회 redis에서 먼저 사용자 정보를 조회후 없을시에 db조회 후 저장후 member를 반환
+     */
+    private Member getRedisMember(Long followId) {
+        return redisService.getMemberDto(followId.toString()).orElseGet(() -> {
+            Member member = memberRepository.findById(followId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.No_SUCH_MEMBER));
+            redisService.setMember(member, Duration.ofDays(7));
+            return member;
+        });
+    }
+
+    /*
+    해당 요청 타입의따라 팔로잉 상태를 String 값으로 반환
+     */
+    private String handleFollowRelationship(Long followerId, Long followingId, Follow follow,FollowType type,String direction) {
+        String status = "";
+        Optional<Follow> existingFollow = followRepository.findByFollowerIdAndFollowingId(followerId, followingId);
+
+        if (existingFollow.isPresent() &&
+                existingFollow.get().getStatus().equals(typeToStatus(type, direction))) {
+            // 연속 요청 발생 시 예외 발생
+            throw new InvalidUsageException(ExceptionStatus.BAD_REQUEST,ExceptionType.ALREADY_REQUESTED);
+        }
+
+        if (type.equals(FollowType.UNFOLLOW)) {     // 언팔로우 이면
+            if (existingFollow.isPresent()) {
+                Follow existing = existingFollow.get();
+                if (direction.equals(TO)) {       // 언팔하려는 사용자일때
+                    if (existing.getStatus().equals(FollowStatus.MUTUAL_FOLLOW)) { // 맞팔로우 상태일때는
+                        existing.updateFollowStatus(FollowStatus.UNFOLLOW); // 언팔
+                        status = UNFOLLOW;
+                    }else if (existing.getStatus().equals(FollowStatus.FOLLOWING)){   // 맞팔 되어있지않고 팔로우만 한상태일때
+                        existing.updateFollowStatus(FollowStatus.CANCEL);   // 팔로우 취소로 변경
+                        status = CANCEL_FOLLOW;
+                    }
+                } else {        // 언팔 대상자
+                    if (existing.getStatus().equals(FollowStatus.MUTUAL_FOLLOW))    // 맞팔상태일때
+                        existing.updateFollowStatus(FollowStatus.FOLLOWING);        // 팔로워 상태로 업데이트
+                    else if (existing.getStatus().equals(FollowStatus.REQUEST)){    // 요청 살태일때는
+                        existing.updateFollowStatus(FollowStatus.CANCEL);   // 요청 취소
+                    }else{
+                        existing.updateFollowStatus(FollowStatus.CANCEL);       // 모두 취소 상태 업데이트
+                    }
+                }
+            }
+        } else {      // 팔로우 요청일 때
+            if (existingFollow.isEmpty()) {     // 비어 있다면 팔로우 요청
+                followRepository.save(follow);
+                status = REQUEST_FOLLOW;
+            } else {
+                Follow existing = existingFollow.get(); // 팔로워 객체
+
+                if (existing.getStatus().equals(FollowStatus.CANCEL)) {    // 취소된 상태에서 팔로우 요청을 한다면
+                    if (direction.equals(TO)) {      // 요청자일 때
+                        existing.updateFollowStatus(FollowStatus.FOLLOWING); // 팔로잉 상태로 업데이트
+                        status = REQUEST_FOLLOW;  
+                    } else {
+                        existing.updateFollowStatus(FollowStatus.REQUEST);   // 대상자는 요청 상태로 변경
+                    }
+                } else {
+                    existing.updateFollowStatus(FollowStatus.MUTUAL_FOLLOW); // MUTUAL_FOLLOW 상태로 업데이트
+                    status = MUTUAL_FOLLOW;
+                }
+            }
+        }
+        return status;
+    }
+
+    private FollowStatus typeToStatus(FollowType type, String direction) {
+        if (type.equals(FollowType.UNFOLLOW)) {
+            return direction.equals(TO) ? FollowStatus.UNFOLLOW : FollowStatus.CANCEL;
+        } else {
+            return direction.equals(TO) ? FollowStatus.FOLLOWING : FollowStatus.REQUEST;
+        }
+    }
+}

--- a/src/main/java/team9499/commitbody/global/Exception/ExceptionType.java
+++ b/src/main/java/team9499/commitbody/global/Exception/ExceptionType.java
@@ -12,6 +12,7 @@ public enum ExceptionType {
     ACCESS_DENIED("이 리소스에 접근할 권한이 없습니다."),
     DUPLICATE_NICKNAME("중복된 닉네임 입니다."),
     INVALID_IMAGE_FORMAT("올바른 이미지 형식이 아닙니다."),
+    ALREADY_REQUESTED("이미 처리된 요청입니다."),
     AUTHOR_ONLY("작성자만 이용할 수 있습니다.");
 
 

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
@@ -43,6 +43,9 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     @Value("${jwt.refresh}")
     private int expired;        // 만료시간
 
+    @Value("${default.profile}")
+    private String profileUrl;
+
     private final String REFRESH_TOKEN = "refreshToken";
     private final String JOIN = "회원가입";
     private final String LOGIN = "로그인";
@@ -54,7 +57,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         Optional<Member> optionalMember = memberRepository.findBySocialId(socialId);
 
         if (!optionalMember.isPresent()){
-            Member member = memberRepository.save(Member.createSocialId(socialId,loginType));
+            Member member = memberRepository.save(Member.createSocialId(socialId,loginType,profileUrl));
             optionalMember = Optional.of(member);
             joinOrLogin = JOIN;
         }

--- a/src/main/java/team9499/commitbody/global/config/CustomMySQLDialect.java
+++ b/src/main/java/team9499/commitbody/global/config/CustomMySQLDialect.java
@@ -1,0 +1,21 @@
+package team9499.commitbody.global.config;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.StandardBasicTypes;
+
+public class CustomMySQLDialect implements FunctionContributor {
+
+    private static final String FUNCTION_PATTERN = "match (?1) against (?2 in boolean mode)";
+    @Override
+    public void contributeFunctions(FunctionContributions functionContributions) {
+        BasicType<Double> resultType = functionContributions
+                .getTypeConfiguration()
+                .getBasicTypeRegistry()
+                .resolve(StandardBasicTypes.DOUBLE);
+
+        functionContributions.getFunctionRegistry()
+                .registerPattern("match",FUNCTION_PATTERN,resultType);
+    }
+}

--- a/src/main/java/team9499/commitbody/global/config/HibernateConfig.java
+++ b/src/main/java/team9499/commitbody/global/config/HibernateConfig.java
@@ -1,0 +1,13 @@
+package team9499.commitbody.global.config;
+
+import org.hibernate.boot.model.FunctionContributor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HibernateConfig{
+    @Bean
+    public FunctionContributor customFunctionContributor() {
+        return new CustomMySQLDialect();
+    }
+}

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+team9499.commitbody.global.config.CustomMySQLDialect


### PR DESCRIPTION
## 개요
- 사용자 도메인의 계정상태, 사용자 프로필을 필드를 추가했습니다.
- 커뮤니티와 사용자의 상호작용을 위한 팔로워기능을 구현했습니다.
- QueryDsl에서 match() 함수를 사용하기위해 mysql config 작성했습니다.
- 팔로워 Controller Swagger 문서 작성

Resolves: #58, #57

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).