### PR TITLE
사용자 검색 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -1,0 +1,32 @@
+package team9499.commitbody.domain.Member.contorller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team9499.commitbody.domain.Member.dto.response.MemberInfoResponse;
+import team9499.commitbody.domain.Member.service.MemberDocService;
+import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.payload.SuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MemberController {
+
+    private final MemberDocService memberDocService;
+
+    @GetMapping("/search/member")
+    public ResponseEntity<?> getTest(@RequestParam(value = "nickname",required = false) String nickname,
+                                     @RequestParam(value = "size",required = false) Integer size,
+                                     @RequestParam(value = "from",required = false) Integer from,
+                                     @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = principalDetails.getMember().getId();
+        int fromValue = (from != null) ? from : 0; // 기본값 0
+        int sizeValue = (size != null) ? size : 10; // 기본값 10
+
+        MemberInfoResponse memberForNickname = memberDocService.findMemberForNickname(memberId, nickname, fromValue, sizeValue);
+
+        return ResponseEntity.ok(new SuccessResponse<>(true,"검색 성공",memberForNickname));
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -1,5 +1,11 @@
 package team9499.commitbody.domain.Member.contorller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -7,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.Member.dto.response.MemberInfoResponse;
 import team9499.commitbody.domain.Member.service.MemberDocService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
 
 @RestController
@@ -16,6 +23,14 @@ public class MemberController {
 
     private final MemberDocService memberDocService;
 
+    @Operation(summary = "사용자 검색", description = "사용자 닉네임을 통해 회원을 검색합니다. default size : 10, default form : 0",tags = "팔로워")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"검색 성공\", \"data\": {\"totalCount\": 2, \"members\": [{\"memberId\": 1, \"nickname\": \"https://example.com\", \"profile\": \"첫번째 닉네임\"}, {\"memberId\": 2, \"nickname\": \"https://example.com\", \"profile\": \"두번째 닉네임\"}]}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/search/member")
     public ResponseEntity<?> getTest(@RequestParam(value = "nickname",required = false) String nickname,
                                      @RequestParam(value = "size",required = false) Integer size,

--- a/src/main/java/team9499/commitbody/domain/Member/domain/MemberDoc.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/MemberDoc.java
@@ -1,0 +1,34 @@
+package team9499.commitbody.domain.Member.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.WriteTypeHint;
+
+@Data
+@Builder
+@Document(indexName = "member_index", writeTypeHint = WriteTypeHint.FALSE)
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+public class MemberDoc {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text, name = "nickname")
+    private String nickname;
+
+    @Field(type = FieldType.Text, name = "profile")
+    private String profile;
+
+    public static MemberDoc create(String id,String nickname, String profile){
+        return new MemberDoc(id,nickname,profile);
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/Member/dto/MemberDto.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/MemberDto.java
@@ -1,5 +1,6 @@
 package team9499.commitbody.domain.Member.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,6 +25,8 @@ public class MemberDto {
     private String socialId;    // 소셜로그인 사용자 ID
 
     private String nickname;    // 닉네임
+    
+    private String profile;     // 사용자 프로필
 
     private String height;      // 키
 
@@ -39,17 +42,23 @@ public class MemberDto {
 
     private Float BodyFatPercentage; // 체지방량
 
-    private boolean notificationEnabled; //알림 유무
-
     private WeightUnit weightUnit; // 무게 타입 (KG, LB)
 
     private LoginType loginType;        //로그인 타입 (KAKAO, GOOGLE)
 
+    @JsonIgnore
+    private boolean notificationEnabled; //알림 유무
+
+    @JsonIgnore
     private boolean isUserDeactivated; //알림유무(true : 알림 받기, false : 알림 안받기)
 
 
     public MemberDto toMemberDTO(Member member){
         return MemberDto.builder()
                 .memberId(member.getId()).nickname(member.getNickname()).build();
+    }
+
+    public static MemberDto createNickname(Long memberId,String profile ,String nickname){
+        return MemberDto.builder().profile(profile).memberId(memberId).nickname(nickname).build();
     }
 }

--- a/src/main/java/team9499/commitbody/domain/Member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/response/MemberInfoResponse.java
@@ -1,0 +1,18 @@
+package team9499.commitbody.domain.Member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import team9499.commitbody.domain.Member.dto.MemberDto;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberInfoResponse {
+
+    private Long totalCount;
+
+    private List<MemberDto> members;
+}

--- a/src/main/java/team9499/commitbody/domain/Member/repository/MemberDocRepository.java
+++ b/src/main/java/team9499/commitbody/domain/Member/repository/MemberDocRepository.java
@@ -1,0 +1,9 @@
+package team9499.commitbody.domain.Member.repository;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.domain.Member.domain.MemberDoc;
+
+@Repository
+public interface MemberDocRepository extends ElasticsearchRepository<MemberDoc,String> {
+}

--- a/src/main/java/team9499/commitbody/domain/Member/service/MemberDocService.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/MemberDocService.java
@@ -1,0 +1,98 @@
+package team9499.commitbody.domain.Member.service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.*;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9499.commitbody.domain.Member.domain.MemberDoc;
+import team9499.commitbody.domain.Member.dto.MemberDto;
+import team9499.commitbody.domain.Member.dto.response.MemberInfoResponse;
+import team9499.commitbody.domain.Member.repository.MemberDocRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberDocService {
+
+    private final MemberDocRepository memberDocRepository;
+    private final ElasticsearchClient elasticsearchClient;
+
+    private final String NICKNAME_FIELD = "nickname";
+    private final String MEMBER_INDEX = "member_index";
+    private final String ID ="id";
+
+    /**
+     * 회원가입시 회원 DOC에 닉네임을 비동기로 저장
+     */
+    @Async
+    public void saveMemberDocAsync(MemberDoc memberDoc) {
+        memberDocRepository.save(memberDoc);
+    }
+
+    /**
+     * 닉네임을 통해 가입된 사용자 검색 - 엘라스틱 서치 사용
+     * @param memberId  현재 로그인한 사용자 ID
+     * @param nickname  검색할 사용자 닉네임
+     * @param from  시작 페이지
+     * @param size  페이지당 최대 크기
+     * @return MemberInfoResponse 객체 반호나
+     */
+    public MemberInfoResponse findMemberForNickname(Long memberId, String nickname, int from, int size) {
+        BoolQuery.Builder builder = new BoolQuery.Builder();    // bool 빌더 생성
+
+        if (nickname != null) {     // 검색할 닉네임 존재시
+            QueryStringQuery query = new QueryStringQuery.Builder()     
+                    .query("*" + nickname + "*")    // 와일드 카드를 이용한 쿼리 생성
+                    .fields(NICKNAME_FIELD)     // 닉네임 필드
+                    .defaultOperator(Operator.And).build();     // and 연산자 사용
+            builder.must(Query.of(q -> q.queryString(query)));
+        }
+
+        // 현재 검색할 사용자는 제외 해야한다.
+        TermQuery termQuery = new TermQuery.Builder()
+                .field("_"+ID)
+                .value(memberId).build();
+        builder.mustNot(Query.of(q -> q.term(termQuery)));
+
+        // 검색 요청 빌더 생성
+        SearchRequest searchRequest = new SearchRequest.Builder()
+                .index(MEMBER_INDEX)
+                .query(Query.of(q -> q.bool(builder.build())))
+                .size(size)
+                .from(from).build();
+
+        MemberInfoResponse memberInfoResponse = new MemberInfoResponse();       // 조회할 데이터를 담은 빈 객체 생성
+
+        try {
+            SearchResponse<Object> search = elasticsearchClient.search(searchRequest, Object.class);        // 검색 요청
+            List<Hit<Object>> hits = search.hits().hits();      // 조회된 데이터를 꺼낸다.
+
+            long value = search.hits().total().value();     // 검색된 총 데이터 수
+            List<MemberDto> memberDtos = new ArrayList<>();
+
+            // hits의 hit 리스트를 돌면서 사용자 id와 사용자 닉네임을 memberDtos 리스트에 담습니다.
+            for (Hit<Object> hit : hits) {
+                Map<String, Object> source = (Map<String, Object>) hit.source();
+                memberDtos.add(MemberDto.createNickname(Long.valueOf(source.get(ID).toString()), source.get(NICKNAME_FIELD).toString(),source.get("profile").toString()));
+            }
+
+            memberInfoResponse.setTotalCount(value);
+            memberInfoResponse.setMembers(memberDtos);
+
+        }catch (Exception e){
+            log.error("회원 검색중 오류 발생");
+        }
+        return memberInfoResponse;
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
@@ -1,0 +1,6 @@
+package team9499.commitbody.domain.Member.service;
+
+public interface MemberService{
+
+    void findMemberForNickname(Long memberId, String nickname);
+}

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
@@ -8,8 +8,10 @@ import org.springframework.transaction.annotation.Transactional;
 import team9499.commitbody.domain.Member.domain.Gender;
 import team9499.commitbody.domain.Member.domain.LoginType;
 import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.domain.Member.domain.MemberDoc;
 import team9499.commitbody.domain.Member.dto.MemberDto;
 import team9499.commitbody.domain.Member.repository.MemberRepository;
+import team9499.commitbody.domain.Member.service.MemberDocService;
 import team9499.commitbody.global.Exception.InvalidUsageException;
 import team9499.commitbody.global.Exception.NoSuchException;
 import team9499.commitbody.global.authorization.domain.RefreshToken;
@@ -38,8 +40,9 @@ public class AuthorizationServiceImpl implements AuthorizationService {
 
     private final RedisService redisService;
     private final MemberRepository memberRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final MemberDocService memberDocService;
     private final JwtUtils jwtUtils;
+    private final RefreshTokenRepository refreshTokenRepository;
     @Value("${jwt.refresh}")
     private int expired;        // 만료시간
 
@@ -77,6 +80,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     public TokenUserInfoResponse additionalInfoSave(String nickName, Gender gender, LocalDate birthday, float height, float weight, Float boneMineralDensity, Float bodyFatPercentage, String jwtToken) {
         String memberId = jwtUtils.accessTokenValid(jwtToken);      // jwt 토큰을 검증후 반환한 memberId
         Member member = memberRepository.findById(Long.parseLong(memberId)).orElseThrow(() -> new NoSuchException(BAD_REQUEST, No_SUCH_MEMBER));
+
+        memberDocService.saveMemberDocAsync(MemberDoc.create(memberId,nickName,member.getProfile()));
 
         if (boneMineralDensity !=null && bodyFatPercentage !=null){
             member.createAdditionalInfoNotNull(nickName,gender,birthday,height,weight,boneMineralDensity,bodyFatPercentage);

--- a/src/main/java/team9499/commitbody/global/config/AsyncConfig.java
+++ b/src/main/java/team9499/commitbody/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package team9499.commitbody.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}


### PR DESCRIPTION
## 개요
- 엘라스틱에 Member Document를 생성하여 회원가입시 회원정보(id,nickname,profile)을 비동기로 저장하도록 구현
- 사용자 검색시 한글자로도 검색을 용이하기 하기위해 엘라스틱을 사용하여 검색할 닉네임을 통해 성능 향상 기대

Resolves: #66 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).