### PR TITLE
마이페이지 - 사용자 정보조회 프로필 수정 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -55,10 +55,12 @@ public class MemberController {
     }
 
     @Tag(name = "프로필",description = "프로필 관련 API")
-    @Operation(summary = "마이페이지 - 사용자 정보 조회", description = "사용자의 정보(닉네임,프로필사진,팔로워/팔로잉)을 조회합니다.")
+    @Operation(summary = "마이페이지 - 사용자 정보 조회", description = "사용자의 정보(닉네임,프로필사진,팔로워/팔로잉)을 조회합니다, pageType[myPage: 마이페이지, theirPage: 상대 페이지], followStatus[FOLLOW_ONLY : 상대방만 팔로워, FOLLOW : 상대방을 팔로우, NEITHER : 서로 팔로워 하지않음]")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"memberId\": 1, \"nickname\": \"첫번쨰닉네임\", \"profile\": \"https://example.com\", \"followerCount\": 0, \"followingCount\": 1}}"))),
+            @ApiResponse(responseCode = "200_1", description = "마이페이지 조회시", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"memberId\": 1, \"pageType\" : \"myPage\",\"nickname\": \"첫번쨰닉네임\", \"profile\": \"https://example.com\", \"followerCount\": 0, \"followingCount\": 1}}"))),
+            @ApiResponse(responseCode = "200_2", description = "상대페이지 조회시", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"memberId\": 1, \"pageType\" : \"theirPage\", \"nickname\": \"첫번쨰닉네임\", \"profile\": \"https://example.com\", \"followerCount\": 0, \"followingCount\": 1,\"followStatus\":\"NEITHER\"}}"))),
             @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
             @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 사용자 존재하지 않을시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -65,10 +65,11 @@ public class MemberController {
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 찾을수 없습니다.\"}"))),
             @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
-    @GetMapping("/myPage")
-    public ResponseEntity<?> myPage(@AuthenticationPrincipal PrincipalDetails principalDetails){
+    @GetMapping("/myPage/{nickname}")
+    public ResponseEntity<?> myPage(@PathVariable("nickname") String nickname,
+                                    @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = getMemberId(principalDetails);
-        MemberMyPageResponse myPage = memberService.getMyPage(memberId);
+        MemberMyPageResponse myPage = memberService.getMyPage(memberId,nickname);
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",myPage));
     }
 

--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -72,6 +72,22 @@ public class MemberController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",myPage));
     }
 
+
+    @Operation(summary = "프로필 수정", description = "해당 사용자의 대한 프로필 정보를 수정가능합니다. 기본 프로필로 설정시 deleteProfile =true, 아닐시는 false를 사용합니다.",tags = "프로필")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\":true,\"message\":\"업데이트 성공\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 값 입렵 검증", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":{\"필드명\": \"오류 내용\"}}"))),
+            @ApiResponse(responseCode = "400_3", description = "BADREQUEST - 파일 용량 초과(5MB 이하만 저장가능)",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"저장 가능한 용량을 초과 했습니다.\"}"))),
+            @ApiResponse(responseCode = "400_4", description = "BADREQUEST - 불가능한 이미지 파일 저장시(jpeg, jpg, png, gif 저장가능)",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"올바른 이미지 형식이 아닙니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
+    })
     @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> updateProfile(@Valid @RequestPart("profileUpdateRequest") ProfileUpdateRequest profileUpdateRequest, BindingResult result,
                                            @RequestPart(name = "file",required = false) MultipartFile file,

--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -11,7 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.domain.Member.dto.response.MemberInfoResponse;
+import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
 import team9499.commitbody.domain.Member.service.MemberDocService;
+import team9499.commitbody.domain.Member.service.MemberService;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
 import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
@@ -22,6 +24,7 @@ import team9499.commitbody.global.payload.SuccessResponse;
 public class MemberController {
 
     private final MemberDocService memberDocService;
+    private final MemberService memberService;
 
     @Operation(summary = "사용자 검색", description = "사용자 닉네임을 통해 회원을 검색합니다. default size : 10, default form : 0",tags = "팔로워")
     @ApiResponses(value = {
@@ -36,12 +39,23 @@ public class MemberController {
                                      @RequestParam(value = "size",required = false) Integer size,
                                      @RequestParam(value = "from",required = false) Integer from,
                                      @AuthenticationPrincipal PrincipalDetails principalDetails){
-        Long memberId = principalDetails.getMember().getId();
+        Long memberId = getMemberId(principalDetails);
         int fromValue = (from != null) ? from : 0; // 기본값 0
         int sizeValue = (size != null) ? size : 10; // 기본값 10
 
         MemberInfoResponse memberForNickname = memberDocService.findMemberForNickname(memberId, nickname, fromValue, sizeValue);
 
         return ResponseEntity.ok(new SuccessResponse<>(true,"검색 성공",memberForNickname));
+    }
+
+    @GetMapping("/myPage")
+    public ResponseEntity<?> myPage(@AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = getMemberId(principalDetails);
+        MemberMyPageResponse myPage = memberService.getMyPage(memberId);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",myPage));
+    }
+
+    private static Long getMemberId(PrincipalDetails principalDetails) {
+        return principalDetails.getMember().getId();
     }
 }

--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -7,10 +7,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import team9499.commitbody.domain.Member.dto.request.ProfileUpdateRequest;
 import team9499.commitbody.domain.Member.dto.response.MemberInfoResponse;
 import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
 import team9499.commitbody.domain.Member.service.MemberDocService;
@@ -65,6 +70,16 @@ public class MemberController {
         Long memberId = getMemberId(principalDetails);
         MemberMyPageResponse myPage = memberService.getMyPage(memberId);
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",myPage));
+    }
+
+    @PutMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<?> updateProfile(@Valid @RequestPart("profileUpdateRequest") ProfileUpdateRequest profileUpdateRequest, BindingResult result,
+                                           @RequestPart(name = "file",required = false) MultipartFile file,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = getMemberId(principalDetails);
+        memberService.updateProfile(memberId, profileUpdateRequest.getNickname(),profileUpdateRequest.getGender(),profileUpdateRequest.getBirthDay(), profileUpdateRequest.getHeight(),
+                profileUpdateRequest.getWeight(),profileUpdateRequest.getBoneMineralDensity(), profileUpdateRequest.getBodyFatPercentage(),profileUpdateRequest.isDeleteProfile(),file);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"업데이트 성공"));
     }
 
     private static Long getMemberId(PrincipalDetails principalDetails) {

--- a/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
+++ b/src/main/java/team9499/commitbody/domain/Member/contorller/MemberController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -48,6 +49,17 @@ public class MemberController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"검색 성공",memberForNickname));
     }
 
+    @Tag(name = "프로필",description = "프로필 관련 API")
+    @Operation(summary = "마이페이지 - 사용자 정보 조회", description = "사용자의 정보(닉네임,프로필사진,팔로워/팔로잉)을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"memberId\": 1, \"nickname\": \"첫번쨰닉네임\", \"profile\": \"https://example.com\", \"followerCount\": 0, \"followingCount\": 1}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 사용자 존재하지 않을시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/myPage")
     public ResponseEntity<?> myPage(@AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = getMemberId(principalDetails);

--- a/src/main/java/team9499/commitbody/domain/Member/domain/Gender.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/Gender.java
@@ -1,5 +1,9 @@
 package team9499.commitbody.domain.Member.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import java.util.Arrays;
+
 public enum Gender {
 
     MALE("남성"),
@@ -21,5 +25,15 @@ public enum Gender {
             }
         }
         return null;
+    }
+
+    @JsonCreator
+    public static Gender fromEventStatus(String val) {
+        if (val ==null || val.equals("")){
+            return null;
+        }
+        return Arrays.stream(values())
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
@@ -5,11 +5,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import team9499.commitbody.global.utils.BaseTime;
 
 import java.time.LocalDate;
 
 @Entity
+@Slf4j
 @Data
 @Builder
 @AllArgsConstructor
@@ -76,5 +78,20 @@ public class Member extends BaseTime {
         this.height = height;
         this.weight = weight;
         this.weightUnit = WeightUnit.KG;
+    }
+
+    public void updateProfile(String nickname, Gender gender, LocalDate birthday, float height, float weight, Float boneMineralDensity, Float bodyFatPercentage,String profile){
+        this.nickname = nickname;
+        this.gender = gender;
+        this.birthday = birthday;
+        this.height = height;
+        this.weight = weight;
+        this.BoneMineralDensity = boneMineralDensity;
+        this.BodyFatPercentage = bodyFatPercentage;
+        if (!this.profile.equals(profile)) {
+            log.info("업데이;트 실행");
+            this.profile = profile;
+        }
+
     }
 }

--- a/src/main/java/team9499/commitbody/domain/Member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/request/ProfileUpdateRequest.java
@@ -1,2 +1,42 @@
-package team9499.commitbody.domain.Member.dto.request;public class ProfileUpdateReuqest {
+package team9499.commitbody.domain.Member.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import team9499.commitbody.domain.Member.domain.Gender;
+import team9499.commitbody.global.annotations.ValidEnum;
+import team9499.commitbody.global.annotations.ValidFloat;
+
+import java.time.LocalDate;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProfileUpdateRequest {
+
+    @NotBlank(message = "변경할 닉네임을 작성해주세요")
+    private String nickname;    // 닉네임
+
+    @ValidEnum(message = "성별을 입력해주세요" ,enumClass = Gender.class)
+    private Gender gender;      // 성별
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Past(message = "생일은 오늘보다 이전이어야 합니다.")
+    private LocalDate birthDay; // 생년월일
+
+    @ValidFloat(message = "변경할 키를 정확하게 입력해주세요",value="height")
+    private Float height;      // 키
+
+    @ValidFloat(message = "변경할 몸무게를 정확하게 입력해주세요",value="weight")
+    private Float weight;      // 몸무게
+
+    @ValidFloat(message = "변경할 골격근량을 정확하게 입력해주세요")
+    private Float boneMineralDensity; // 골격근량
+
+    @ValidFloat(message = "변경할 체지방량을 정확하게 입력해주세요")
+    private Float bodyFatPercentage; // 체지방량
+
+    private boolean deleteProfile; // 프로필 삭제
 }

--- a/src/main/java/team9499/commitbody/domain/Member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/request/ProfileUpdateRequest.java
@@ -1,0 +1,2 @@
+package team9499.commitbody.domain.Member.dto.request;public class ProfileUpdateReuqest {
+}

--- a/src/main/java/team9499/commitbody/domain/Member/dto/request/ProfileUpdateRequest.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/request/ProfileUpdateRequest.java
@@ -1,6 +1,8 @@
 package team9499.commitbody.domain.Member.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,29 +16,38 @@ import java.time.LocalDate;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Tag(name = "프로핑 수정 Request", description = "프로플 수정에 사용되는 Request")
 public class ProfileUpdateRequest {
 
+    @Schema(description = "변경할 닉네임 명")
     @NotBlank(message = "변경할 닉네임을 작성해주세요")
     private String nickname;    // 닉네임
 
+    @Schema(description = "변경할 성별[MALE, FEMALE]")
     @ValidEnum(message = "성별을 입력해주세요" ,enumClass = Gender.class)
     private Gender gender;      // 성별
 
+    @Schema(description = "변경할 생년월일 금일 날짜보다 이전 이어야 합니다.")
     @JsonFormat(pattern = "yyyy-MM-dd")
     @Past(message = "생일은 오늘보다 이전이어야 합니다.")
     private LocalDate birthDay; // 생년월일
 
+    @Schema(description = "변경할 키 입니다. 81 ~299cm 까지 사용 가능합니다.")
     @ValidFloat(message = "변경할 키를 정확하게 입력해주세요",value="height")
     private Float height;      // 키
 
+    @Schema(description = "변경할 몸무게 입니다. 11~199kg 까지 사용 가능합니다.")
     @ValidFloat(message = "변경할 몸무게를 정확하게 입력해주세요",value="weight")
     private Float weight;      // 몸무게
 
+    @Schema(description = "변경할 골격근량 입니다. 1~99까지 사용가능합니다.")
     @ValidFloat(message = "변경할 골격근량을 정확하게 입력해주세요")
     private Float boneMineralDensity; // 골격근량
 
+    @Schema(description = "변경할 체지방량 입니다. 1~99까지 사용가능합니다.")
     @ValidFloat(message = "변경할 체지방량을 정확하게 입력해주세요")
     private Float bodyFatPercentage; // 체지방량
 
+    @Schema(description = "기본 프로필로 사용 할 경우 true를 사용하며, 아닐시 false를 사용합니다.")
     private boolean deleteProfile; // 프로필 삭제
 }

--- a/src/main/java/team9499/commitbody/domain/Member/dto/response/MemberMyPageResponse.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/response/MemberMyPageResponse.java
@@ -1,0 +1,21 @@
+package team9499.commitbody.domain.Member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberMyPageResponse {
+
+    private Long memberId;     // 사용자 id
+
+    private String nickname;   // 사용자 닉네임
+
+    private String profile;     // 사용자 프로필 사진
+
+    private int followerCount;      // 팔로워 수
+
+    private int followingCount;     // 팔로잉 수
+}

--- a/src/main/java/team9499/commitbody/domain/Member/dto/response/MemberMyPageResponse.java
+++ b/src/main/java/team9499/commitbody/domain/Member/dto/response/MemberMyPageResponse.java
@@ -1,15 +1,22 @@
 package team9499.commitbody.domain.Member.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import team9499.commitbody.domain.follow.domain.FollowType;
 
 @Data
+@Builder
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class MemberMyPageResponse {
 
     private Long memberId;     // 사용자 id
+    
+    private String pageType; // 마이페이지, 상대 페이지
 
     private String nickname;   // 사용자 닉네임
 
@@ -18,4 +25,6 @@ public class MemberMyPageResponse {
     private int followerCount;      // 팔로워 수
 
     private int followingCount;     // 팔로잉 수
+    
+    private FollowType followStatus;    // 현재 팔로우 상태
 }

--- a/src/main/java/team9499/commitbody/domain/Member/repository/MemberRepository.java
+++ b/src/main/java/team9499/commitbody/domain/Member/repository/MemberRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findBySocialId(String socialId);
+    Optional<Member> findByNickname(String nickname);
 
     @Query("select m from Member m where binary(m.nickname) = :nickname")
     Member existsByNickname(@Param("nickname") String nickname);

--- a/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
@@ -8,7 +8,7 @@ import java.time.LocalDate;
 
 public interface MemberService{
 
-    MemberMyPageResponse getMyPage(Long memberId);
+    MemberMyPageResponse getMyPage(Long memberId,String nickname);
 
     void updateProfile(Long memberId, String nickname, Gender gender, LocalDate birthDay, Float height, Float weight, Float BoneMineralDensity,
                        Float BodyFatPercentage, boolean deleteProfile,MultipartFile file);

--- a/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
@@ -1,8 +1,15 @@
 package team9499.commitbody.domain.Member.service;
 
+import org.springframework.web.multipart.MultipartFile;
+import team9499.commitbody.domain.Member.domain.Gender;
 import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
+
+import java.time.LocalDate;
 
 public interface MemberService{
 
     MemberMyPageResponse getMyPage(Long memberId);
+
+    void updateProfile(Long memberId, String nickname, Gender gender, LocalDate birthDay, Float height, Float weight, Float BoneMineralDensity,
+                       Float BodyFatPercentage, boolean deleteProfile,MultipartFile file);
 }

--- a/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/MemberService.java
@@ -1,6 +1,8 @@
 package team9499.commitbody.domain.Member.service;
 
+import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
+
 public interface MemberService{
 
-    void findMemberForNickname(Long memberId, String nickname);
+    MemberMyPageResponse getMyPage(Long memberId);
 }

--- a/src/main/java/team9499/commitbody/domain/Member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/impl/MemberServiceImpl.java
@@ -1,8 +1,11 @@
 package team9499.commitbody.domain.Member.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import team9499.commitbody.domain.Member.domain.Gender;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
 import team9499.commitbody.domain.Member.repository.MemberRepository;
@@ -11,7 +14,11 @@ import team9499.commitbody.domain.follow.repository.FollowRepository;
 import team9499.commitbody.global.Exception.ExceptionStatus;
 import team9499.commitbody.global.Exception.ExceptionType;
 import team9499.commitbody.global.Exception.NoSuchException;
+import team9499.commitbody.global.aws.s3.S3Service;
 
+import java.time.LocalDate;
+
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -19,6 +26,8 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
+    private final S3Service s3Service;
+
 
     /**
      * 마이페이지 조회 API
@@ -26,10 +35,38 @@ public class MemberServiceImpl implements MemberService {
      */
     @Override
     public MemberMyPageResponse getMyPage(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.No_SUCH_MEMBER));
+        Member member = getMember(memberId);
         int countFollower = (int) followRepository.getCountFollower(memberId);
         int countFollowing = (int)followRepository.getCountFollowing(memberId);
 
         return new MemberMyPageResponse(member.getId(),member.getNickname(),member.getProfile(),countFollower,countFollowing);
+    }
+
+
+    /**
+     *  프로필 업데이트
+     * @param memberId  수정할 사용자 ID
+     * @param nickname  닉네임
+     * @param gender    성별
+     * @param birthDay  생년월일
+     * @param height    키
+     * @param weight    몸무게
+     * @param boneMineralDensity  골근격량
+     * @param bodyFatPercentage  체지방량
+     * @param deleteProfile 기본 프로필 변경 여부
+     * @param file
+     */
+    @Override
+    public void updateProfile(Long memberId, String nickname, Gender gender, LocalDate birthDay, Float height, Float weight, Float boneMineralDensity,
+                              Float bodyFatPercentage, boolean deleteProfile,MultipartFile file) {
+        Member member = getMember(memberId);
+        String profile = s3Service.updateProfile(file, member.getProfile(),deleteProfile);
+        member.updateProfile(nickname,gender,birthDay,height,weight,boneMineralDensity,bodyFatPercentage,profile);
+    }
+
+
+    private Member getMember(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.No_SUCH_MEMBER));
+        return member;
     }
 }

--- a/src/main/java/team9499/commitbody/domain/Member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/impl/MemberServiceImpl.java
@@ -1,0 +1,35 @@
+package team9499.commitbody.domain.Member.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
+import team9499.commitbody.domain.Member.repository.MemberRepository;
+import team9499.commitbody.domain.Member.service.MemberService;
+import team9499.commitbody.domain.follow.repository.FollowRepository;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.Exception.NoSuchException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final FollowRepository followRepository;
+
+    /**
+     * 마이페이지 조회 API
+     * @param memberId  현재 로그인한 사용자 정보
+     */
+    @Override
+    public MemberMyPageResponse getMyPage(Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.No_SUCH_MEMBER));
+        int countFollower = (int) followRepository.getCountFollower(memberId);
+        int countFollowing = (int)followRepository.getCountFollowing(memberId);
+
+        return new MemberMyPageResponse(member.getId(),member.getNickname(),member.getProfile(),countFollower,countFollowing);
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/follow/domain/FollowType.java
+++ b/src/main/java/team9499/commitbody/domain/follow/domain/FollowType.java
@@ -5,5 +5,9 @@ public enum FollowType {
     FOLLOWING,
     CANCEL,
     MUTUAL_FOLLOW,
-    UNFOLLOW;
+    UNFOLLOW,
+    FOLLOW_ONLY,       // 상대방이 나를 팔로우하고 있지만 나는 그를 팔로우하지 않는 상태
+    BOTH,           // 서로 팔로우 중
+    NEITHER         // 서로 팔로우 하지 않음
+
 }

--- a/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepository.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepository.java
@@ -12,4 +12,8 @@ public interface CustomFollowRepository {
     Slice<FollowingDto> getAllFollowings(Long followerId, String nickName, Long lastId, Pageable pageable);
 
     Slice<FollowerDto> getAllFollowers(Long followerId,String nickName,Long lastId, Pageable pageable);
+
+    long getCountFollowing(Long followerId);
+
+    long getCountFollower(Long followingId);
 }

--- a/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepository.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepository.java
@@ -2,6 +2,8 @@ package team9499.commitbody.domain.follow.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import team9499.commitbody.domain.follow.domain.FollowStatus;
+import team9499.commitbody.domain.follow.domain.FollowType;
 import team9499.commitbody.domain.follow.dto.FollowerDto;
 import team9499.commitbody.domain.follow.dto.FollowingDto;
 
@@ -16,4 +18,6 @@ public interface CustomFollowRepository {
     long getCountFollowing(Long followerId);
 
     long getCountFollower(Long followingId);
+
+    FollowType followStatus(Long followerId, Long followingId);
 }

--- a/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepositoryImpl.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import static team9499.commitbody.domain.Member.domain.QMember.*;
 import static team9499.commitbody.domain.follow.domain.FollowType.FOLLOW_ONLY;
+import static team9499.commitbody.domain.follow.domain.FollowType.NEITHER;
 import static team9499.commitbody.domain.follow.domain.QFollow.*;
 
 @Repository
@@ -125,7 +126,7 @@ public class CustomFollowRepositoryImpl implements CustomFollowRepository{
                 .where(follow.follower.id.eq(followerId).and(follow.following.id.eq(followingId)))
                 .fetchOne();
         //팔로우가 되어 있지 않았을때 검증
-        if (followStatus == null || followStatus.equals(FollowStatus.CANCEL) || followStatus.equals(FollowStatus.UNFOLLOW)){
+        if (followStatus==null || followStatus.equals(FollowStatus.CANCEL) || followStatus.equals(FollowStatus.UNFOLLOW)){
             FollowStatus followStatus1 = jpaQueryFactory.select(follow.status)
                     .from(follow)
                     .where(follow.follower.id.eq(followingId).and(follow.following.id.eq(followerId))).fetchOne();
@@ -135,8 +136,7 @@ public class CustomFollowRepositoryImpl implements CustomFollowRepository{
                 type = FOLLOW_ONLY;
             }
         }
-        // 현재 내가 상대방을 팔로워나 맞팔로워 되어있을때
-        if (followStatus.equals(FollowStatus.FOLLOWING)|| followStatus.equals(FollowStatus.MUTUAL_FOLLOW))       // 팔로우 상태
+        else if (followStatus.equals(FollowStatus.FOLLOWING)|| followStatus.equals(FollowStatus.MUTUAL_FOLLOW))       // 팔로우 상태
             type = FollowType.FOLLOW;
         else if (followStatus.equals(FollowStatus.REQUEST)) {   // 상대방이 팔로우 요청을 보낸 상태라면
             type = FOLLOW_ONLY;

--- a/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/follow/repository/CustomFollowRepositoryImpl.java
@@ -90,6 +90,24 @@ public class CustomFollowRepositoryImpl implements CustomFollowRepository{
         return new SliceImpl<>(followerDtoList,pageable,hasNext);
     }
 
+    @Override
+    public long getCountFollowing(Long followerId) {
+        return jpaQueryFactory.select(follow.count())
+                .from(follow)
+                .join(member).on(member.id.eq(follow.following.id))
+                .where(follow.follower.id.eq(followerId).and(follow.status.eq(FollowStatus.FOLLOWING).or(follow.status.eq(FollowStatus.MUTUAL_FOLLOW)))).fetchOne();
+    }
+
+    @Override
+    public long getCountFollower(Long followingId) {
+
+        return jpaQueryFactory.select(follow.count())
+                .from(follow)
+                .join(member).on(member.id.eq(follow.follower.id))  // 올바른 조인 조건
+                .where(follow.following.id.eq(followingId).and(follow.status.eq(FollowStatus.FOLLOWING).or(follow.status.eq(FollowStatus.MUTUAL_FOLLOW))))  // 올바른 조건
+                .fetchOne();
+    }
+
     private static boolean checkFollow(FollowStatus followStatus){
         return followStatus.equals(FollowStatus.FOLLOWING) ? false : true;
     }

--- a/src/main/java/team9499/commitbody/global/annotations/FloatValidator.java
+++ b/src/main/java/team9499/commitbody/global/annotations/FloatValidator.java
@@ -1,0 +1,37 @@
+package team9499.commitbody.global.annotations;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class FloatValidator implements ConstraintValidator<ValidFloat,Float> {
+
+    private ValidFloat validFloat;
+    private String requestValue;
+
+    @Override
+    public void initialize(ValidFloat constraintAnnotation) {
+        this.validFloat = constraintAnnotation;
+        this.requestValue = constraintAnnotation.value();
+    }
+    @Override
+    public boolean isValid(Float value, ConstraintValidatorContext context) {
+        boolean status = true;
+        if (requestValue.equals("weight")){     // 몸무게 검증(10 ~ 199)
+            if (value<=10.0 || value>200.0){
+                status =  false;
+            }
+        }else if (requestValue.equals("height")){       // 키 검증 (80 ~ 300)
+            if (value<=80.0 || value>300.0){
+                status =  false;
+            }
+        }else {
+            if (value<=0.0 || value>100.0){     // 골격근량, 체지방량 검증(0~100)
+                status =  false;
+            }
+        }
+
+        return status;
+    }
+}

--- a/src/main/java/team9499/commitbody/global/annotations/ValidFloat.java
+++ b/src/main/java/team9499/commitbody/global/annotations/ValidFloat.java
@@ -1,0 +1,20 @@
+package team9499.commitbody.global.annotations;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = FloatValidator.class)
+@Target({ElementType.METHOD,ElementType.FIELD,ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidFloat {
+
+    String message() default "Invalid float value";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    String value() default "";
+}

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -40,7 +40,7 @@ public class AuthorizationController {
     @Operation(summary = "회원가입/로그인", description = "매 요청마다 소셜 로그인 정보를 전달해야합니다. 최초 로그인 시에는 회원가입이 진행되며, 이후 로그인이 진행됩니다. 로그인 시에만 tokenInfo에 사용자 정보가 포함됩니다.(authMode: [로그인,회원가입])")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",description = "0K", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
-            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"성공\",\"data\":{\"refreshToken\":\"sample_refresh_token\",\"accessToken\":\"sample_access_token\",\"authMode\":\"타입 종류\",\"tokenInfo\":{\"memberId\":1}}}"))),
+            examples = @ExampleObject(value = "{\"success\":true,\"message\":\"성공\",\"data\":{\"refreshToken\":\"sample_refresh_token\",\"accessToken\":\"sample_access_token\",\"authMode\":\"타입 종류\",\"tokenInfo\":{\"memberId\":1,\"nickname\":\"닉네임\"}}}"))),
             @ApiResponse(responseCode = "400",description = "BADREQUEST", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
                     examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
             @ApiResponse(responseCode = "401",description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),

--- a/src/main/java/team9499/commitbody/global/authorization/dto/TokenInfoDto.java
+++ b/src/main/java/team9499/commitbody/global/authorization/dto/TokenInfoDto.java
@@ -9,8 +9,19 @@ public class TokenInfoDto {
 
     private Long memberId;
 
-    private TokenInfoDto(Long memberId) {
+    private String nickname;
+
+    public TokenInfoDto(Long memberId) {
         this.memberId = memberId;
+    }
+
+    private TokenInfoDto(Long memberId, String nickname) {
+        this.memberId = memberId;
+        this.nickname = nickname;
+    }
+
+    public static TokenInfoDto of(Long memberId,String nickname){
+        return new TokenInfoDto(memberId,nickname);
     }
 
     public static TokenInfoDto of(Long memberId){

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
@@ -71,7 +71,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         Map<String, Object> tokenMap = new LinkedHashMap<>(jwtUtils.generateAuthTokens(MemberDto.builder().memberId(optionalMember.get().getId()).build()));
         tokenMap.put("authMode",joinOrLogin);       // 로그인 / 회원가입을 구분하기위함
 
-        if (joinOrLogin.equals(LOGIN)) tokenMap.put("tokenInfo",TokenInfoDto.of(optionalMember.get().getId()));     //로그인일 경우에만 JWT토큰의대한 정보를 담는다
+        if (joinOrLogin.equals(LOGIN)) tokenMap.put("tokenInfo",TokenInfoDto.of(optionalMember.get().getId(),optionalMember.get().getNickname()));     //로그인일 경우에만 JWT토큰의대한 정보를 담는다
         SaveRefreshToken(optionalMember.get().getId(), optionalMember, (String) tokenMap.get(REFRESH_TOKEN));
         return tokenMap;
     }

--- a/src/main/java/team9499/commitbody/global/aws/s3/S3Service.java
+++ b/src/main/java/team9499/commitbody/global/aws/s3/S3Service.java
@@ -5,5 +5,6 @@ import org.springframework.web.multipart.MultipartFile;
 public interface S3Service {
     String uploadImage(MultipartFile file);
     String updateImage(MultipartFile file, String previousFileName);
+    String updateProfile(MultipartFile file, String previousFileName, boolean deleteProfile);
     void deleteImage(String fileName);
 }

--- a/src/main/java/team9499/commitbody/global/aws/s3/S3ServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/aws/s3/S3ServiceImpl.java
@@ -30,6 +30,12 @@ public class S3ServiceImpl implements S3Service{
     @Value("${cloud.aws.s3.bucket.image}")
     private String bucketImage;
 
+    @Value("${default.profile}")
+    private String defaultProfile;
+
+    @Value("${cloud.aws.cdn.url}")
+    private String cdnUrl;
+
     /**
      * 파일 업로드
      * 저장된 파일명을 반환한다.
@@ -67,6 +73,30 @@ public class S3ServiceImpl implements S3Service{
             deleteImage(previousFileName);
             previous = uploadImage(file);
         }
+        return previous;
+    }
+
+    /**
+     * 프로필 사진 업데이트
+     * 기본 이미지파일을 경우 이미지파일을 업데이트하고 변경된 프로필 사진을 경우 기존 이미지 파일을 삭제후 새로운 프로플 사진을 업데이트
+     * @param file
+     * @param previousFileName  이전 프로필 파일 이름
+     * @return
+     */
+    @Override
+    public String updateProfile(MultipartFile file, String previousFileName,boolean deleteProfile) {
+        String previous = previousFileName;
+        if (deleteProfile){     // 기본 프로필 적용시
+            previous = defaultProfile;
+            deleteImage(previousFileName.replace(cdnUrl, ""));
+        }
+        if (file!=null) {
+            if (!previous.equals(defaultProfile)){      // 기본 프로필 사진이 아닐 경우 기존 프로필 사진을 삭제
+                deleteImage(previousFileName.replace(cdnUrl, ""));
+            }
+            previous = cdnUrl+uploadImage(file);
+        }
+
         return previous;
     }
 


### PR DESCRIPTION
## 개요
- 마이페이지에 접근시 nickname을통해 페이지 정보를 볼수있으며, 하나의 API를통해서 마이 페이지, 상대 페에지를 사용하도록 구현했습니다.
- Float타입을 @Valid를 하기위해서 커스텀 에노테이션을 만들어 @Valid 적용
- 프로필 사진 관련 로직 구현
- 로그인시 사용자의 닉네임도 반환하도록 리팩토링
- 게시글 관련 구현은 게시글 구현후 추가 예정 

Ref : #68 

## PR 유형
어떤 변경 사항이 있나요?

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).