### PR TITLE
Fcm 알림 - 팔로우(요청/취소) 알림 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ out/
 
 ### VS Code ###
 .vscode/
+/src/main/resources/firebase/commitbody-6773d-firebase-adminsdk-w2bx9-1a603087d1.json
+/src/main/resources/templates/
+/src/main/resources/static/
+/src/main/java/team9499/commitbody/test/

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'com.nimbusds:nimbus-jose-jwt:9.15'
 	implementation 'com.auth0:java-jwt:4.4.0'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
+++ b/src/main/java/team9499/commitbody/domain/Member/domain/Member.java
@@ -51,8 +51,6 @@ public class Member extends BaseTime {
     @Enumerated(EnumType.STRING)
     private LoginType loginType;        //로그인 타입 (KAKAO, GOOGLE)
 
-    private boolean isUserDeactivated; //알림유무(true : 알림 받기, false : 알림 안받기)
-
     @Enumerated(EnumType.STRING)
     private AccountStatus accountStatus;        // 계정 상태 - PUBLIC : 공개(기본 값) , PRIVATE : 비공개
 

--- a/src/main/java/team9499/commitbody/domain/record/domain/RecordDetails.java
+++ b/src/main/java/team9499/commitbody/domain/record/domain/RecordDetails.java
@@ -105,4 +105,13 @@ public class RecordDetails {
         return detailsBuilder.build();
     }
 
+    public RecordDetails onlyExercise(Object exercise) {
+        RecordDetailsBuilder builder = RecordDetails.builder();
+        if (exercise instanceof Exercise)
+            builder.exercise((Exercise) exercise);
+        else
+            builder.customExercise((CustomExercise) exercise);
+
+        return builder.build();
+    }
 }

--- a/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
+++ b/src/main/java/team9499/commitbody/global/authorization/controller/AuthorizationController.java
@@ -48,7 +48,9 @@ public class AuthorizationController {
     })
     @PostMapping("/auth")
     public ResponseEntity<SuccessResponse> socialLogin(@RequestBody JoinLoginRequest joinLoginRequest){
-        Map<String, Object> jwtTokenMap = authorizationService.authenticateOrRegisterUser(joinLoginRequest.getLoginType(), joinLoginRequest.getSocialId());
+        Map<String, Object> jwtTokenMap = authorizationService.authenticateOrRegisterUser(
+                joinLoginRequest.getLoginType(), joinLoginRequest.getSocialId(),joinLoginRequest.getFcmToken()
+        );
 
         return ResponseEntity.ok().body(new SuccessResponse<>(true,"성공",jwtTokenMap));
     }
@@ -65,7 +67,8 @@ public class AuthorizationController {
                             examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))
     })
     @PostMapping("/additional-info")
-    public ResponseEntity<?> additionalInfo(@Valid @RequestBody AdditionalInfoReqeust additionalInfoReqeust, BindingResult result,HttpServletRequest request){
+    public ResponseEntity<?> additionalInfo(@Valid @RequestBody AdditionalInfoReqeust additionalInfoReqeust, BindingResult result,
+                                            HttpServletRequest request){
         String jwtToken = getJwtToken(request);
 
         TokenUserInfoResponse tokenUserInfoResponse = authorizationService.additionalInfoSave(

--- a/src/main/java/team9499/commitbody/global/authorization/dto/JoinLoginRequest.java
+++ b/src/main/java/team9499/commitbody/global/authorization/dto/JoinLoginRequest.java
@@ -13,4 +13,6 @@ public class JoinLoginRequest {
 
     @Schema(description = "회원가입시 필요한 소셜로그인 Id")
     private String socialId;
+
+    private String fcmToken;
 }

--- a/src/main/java/team9499/commitbody/global/authorization/service/AuthorizationService.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/AuthorizationService.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public interface AuthorizationService {
 
-    Map<String,Object> authenticateOrRegisterUser(LoginType loginType,String socialId);
+    Map<String,Object> authenticateOrRegisterUser(LoginType loginType,String socialId,String fcmToken);
 
     TokenUserInfoResponse additionalInfoSave(String nickName, Gender gender, LocalDate birthday, float height, float weight, Float boneMineralDensity, Float bodyFatPercentage, String jwtToken);
 

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
@@ -55,7 +55,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
     private final String NICKNAME ="nickname_";
 
     @Override
-    public Map<String,Object> authenticateOrRegisterUser(LoginType loginType,String socialId) {
+    public Map<String,Object> authenticateOrRegisterUser(LoginType loginType,String socialId,String fcmToken) {
         String joinOrLogin = "";
         Optional<Member> optionalMember = memberRepository.findBySocialId(socialId);
 
@@ -70,6 +70,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
 
         Map<String, Object> tokenMap = new LinkedHashMap<>(jwtUtils.generateAuthTokens(MemberDto.builder().memberId(optionalMember.get().getId()).build()));
         tokenMap.put("authMode",joinOrLogin);       // 로그인 / 회원가입을 구분하기위함
+
+        redisService.setFCM(String.valueOf(optionalMember.get().getId()),fcmToken);     // fcm 토큰 레디스에 저장
 
         if (joinOrLogin.equals(LOGIN)) tokenMap.put("tokenInfo",TokenInfoDto.of(optionalMember.get().getId(),optionalMember.get().getNickname()));     //로그인일 경우에만 JWT토큰의대한 정보를 담는다
         SaveRefreshToken(optionalMember.get().getId(), optionalMember, (String) tokenMap.get(REFRESH_TOKEN));

--- a/src/main/java/team9499/commitbody/global/config/FCMInitializer.java
+++ b/src/main/java/team9499/commitbody/global/config/FCMInitializer.java
@@ -1,0 +1,38 @@
+package team9499.commitbody.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+
+
+@Component
+@Slf4j
+public class FCMInitializer {
+
+    @Value("${fcm.firebase_config_path}")
+    private String firebaseConfigPath;
+
+    @PostConstruct
+    public void initialize(){
+        try {
+            GoogleCredentials googleCredentials = GoogleCredentials.
+                    fromStream(new ClassPathResource(firebaseConfigPath).getInputStream());
+            FirebaseOptions options = new FirebaseOptions.Builder()
+                    .setCredentials(googleCredentials)
+                    .build();
+            if (FirebaseApp.getApps().isEmpty()){
+                FirebaseApp.initializeApp(options);
+                log.info("FirebaseApp initialization complete");
+            }
+        }catch (IOException e){
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/team9499/commitbody/global/notification/controller/NotificationController.java
+++ b/src/main/java/team9499/commitbody/global/notification/controller/NotificationController.java
@@ -1,0 +1,27 @@
+package team9499.commitbody.global.notification.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.notification.service.NotificationService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping("/notification/read")
+    public void updateNotificationRead(@AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = getMemberId(principalDetails);
+        notificationService.updateRead(memberId);
+    }
+
+    private static Long getMemberId(PrincipalDetails principalDetails) {
+        return principalDetails.getMember().getId();
+    }
+}

--- a/src/main/java/team9499/commitbody/global/notification/domain/Notification.java
+++ b/src/main/java/team9499/commitbody/global/notification/domain/Notification.java
@@ -1,0 +1,40 @@
+package team9499.commitbody.global.notification.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.global.utils.BaseTime;
+
+@Data
+@Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@ToString(exclude = {"receiver","sender"})
+public class Notification extends BaseTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;            // id(pk)
+
+    @Column(length = 1000)
+    private String content;  // 알림 내용
+
+    private Integer isRead;       // 알림 읽음 상태   (0 : 안읽음 상태 , 1 : 읽은 상태)
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;  // 알림 종류(팔로우, 댓글 , 좋아요, 전체알림)
+
+    @JoinColumn(name = "receiver_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member receiver;      // 수신자
+
+    @JoinColumn(name = "sender_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member sender;      // 발신자
+
+    public static Notification of(String content,NotificationType notificationType,Member receiver,Member sender){
+        return Notification.builder().content(content).notificationType(notificationType).receiver(receiver).sender(sender).isRead(0).build();
+    }
+}

--- a/src/main/java/team9499/commitbody/global/notification/domain/NotificationType.java
+++ b/src/main/java/team9499/commitbody/global/notification/domain/NotificationType.java
@@ -1,0 +1,6 @@
+package team9499.commitbody.global.notification.domain;
+
+public enum NotificationType {
+
+    FOLLOW,COMMENT,LIKE
+}

--- a/src/main/java/team9499/commitbody/global/notification/event/DeleteFollowEvent.java
+++ b/src/main/java/team9499/commitbody/global/notification/event/DeleteFollowEvent.java
@@ -1,2 +1,16 @@
-package team9499.commitbody.global.notification.event;public class DeleteFollowEvent {
+package team9499.commitbody.global.notification.event;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteFollowEvent {
+
+    private Long followerId;
+
+    private Long followingId;
+
+    public DeleteFollowEvent(Long followerId, Long followingId) {
+        this.followerId = followerId;
+        this.followingId = followingId;
+    }
 }

--- a/src/main/java/team9499/commitbody/global/notification/event/DeleteFollowEvent.java
+++ b/src/main/java/team9499/commitbody/global/notification/event/DeleteFollowEvent.java
@@ -1,0 +1,2 @@
+package team9499.commitbody.global.notification.event;public class DeleteFollowEvent {
+}

--- a/src/main/java/team9499/commitbody/global/notification/event/FollowingEvent.java
+++ b/src/main/java/team9499/commitbody/global/notification/event/FollowingEvent.java
@@ -1,0 +1,16 @@
+package team9499.commitbody.global.notification.event;
+
+import lombok.Getter;
+
+@Getter
+public class FollowingEvent {
+
+    private Long follower;
+
+    private Long following;
+
+    public FollowingEvent(Long follower, Long following) {
+        this.follower = follower;
+        this.following = following;
+    }
+}

--- a/src/main/java/team9499/commitbody/global/notification/event/NotificationHandler.java
+++ b/src/main/java/team9499/commitbody/global/notification/event/NotificationHandler.java
@@ -15,4 +15,8 @@ public class NotificationHandler {
     public void Following(FollowingEvent followingEvent){
         notificationService.sendFollowing(followingEvent.getFollower(), followingEvent.getFollowing());
     }
+    @EventListener
+    public void DeleteFollowNotification(DeleteFollowEvent deleteFollowEvent){
+        notificationService.deleteNotification(deleteFollowEvent.getFollowerId(), deleteFollowEvent.getFollowingId());
+    }
 }

--- a/src/main/java/team9499/commitbody/global/notification/event/NotificationHandler.java
+++ b/src/main/java/team9499/commitbody/global/notification/event/NotificationHandler.java
@@ -1,0 +1,18 @@
+package team9499.commitbody.global.notification.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import team9499.commitbody.global.notification.service.NotificationService;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationHandler {
+
+    private final NotificationService notificationService;
+
+    @EventListener
+    public void Following(FollowingEvent followingEvent){
+        notificationService.sendFollowing(followingEvent.getFollower(), followingEvent.getFollowing());
+    }
+}

--- a/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
@@ -1,9 +1,16 @@
 package team9499.commitbody.global.notification.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team9499.commitbody.global.notification.domain.Notification;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification,Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Notification n SET n.isRead = 1 WHERE n.receiver.id IN :receiverId AND n.isRead = 0")
+    int updateRead(@Param("receiverId") Long receiverId);
 }

--- a/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
@@ -6,11 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import team9499.commitbody.global.notification.domain.Notification;
+import team9499.commitbody.global.notification.domain.NotificationType;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<Notification,Long> {
-
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Notification n SET n.isRead = 1 WHERE n.receiver.id IN :receiverId AND n.isRead = 0")
     int updateRead(@Param("receiverId") Long receiverId);
+    void deleteByReceiverIdAndSenderIdAndNotificationType(Long receiverId, Long senderId, NotificationType notificationType);
 }

--- a/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
@@ -1,0 +1,9 @@
+package team9499.commitbody.global.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.global.notification.domain.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification,Long> {
+}

--- a/src/main/java/team9499/commitbody/global/notification/service/FcmService.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/FcmService.java
@@ -1,0 +1,54 @@
+package team9499.commitbody.global.notification.service;
+
+import com.google.api.core.ApiFuture;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9499.commitbody.global.redis.RedisService;
+
+import java.util.concurrent.ExecutionException;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class FcmService {
+
+    private final RedisService redisService;
+
+    public void sendFollowingMessage(String followingId,String content){
+        String fcmToken = redisService.getFCMToken(followingId);
+
+        if (fcmToken.equals("")) return;
+
+        // 메시 객체 생성
+        Message message = Message.builder()
+                .setToken(fcmToken)
+                .setNotification(Notification.builder()
+                        .setTitle("팔로우 알림")
+                        .setBody(content)
+                        .build())
+                // TODO: 2024-09-02 프론트앤드 url 주소 확정시 url 추가
+//                .putData("click_action", "http://localhost:8080")
+                .build();
+
+        send(message);
+    }
+
+    private void send(Message message) {
+        ApiFuture<String> response = FirebaseMessaging.getInstance().sendAsync(message);    // 비동기 전송
+        // 전송 결과 확인
+        try {
+            String messageId = response.get(); // 성공 시 메시지 ID 반환
+            log.info("알림이 성공적으로 전송되었습니다. 메시지 ID: {}", messageId);
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("알림 전송에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+
+}

--- a/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
@@ -1,0 +1,7 @@
+package team9499.commitbody.global.notification.service;
+
+public interface NotificationService {
+
+    void sendFollowing(Long followerId, Long followingId);
+
+}

--- a/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
@@ -3,6 +3,6 @@ package team9499.commitbody.global.notification.service;
 public interface NotificationService {
 
     void sendFollowing(Long followerId, Long followingId);
-
     void updateRead(Long receiverId);
+    void deleteNotification(Long followerId, Long followingId);
 }

--- a/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
@@ -4,4 +4,5 @@ public interface NotificationService {
 
     void sendFollowing(Long followerId, Long followingId);
 
+    void updateRead(Long receiverId);
 }

--- a/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
@@ -1,0 +1,52 @@
+package team9499.commitbody.global.notification.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.global.notification.domain.Notification;
+import team9499.commitbody.global.notification.domain.NotificationType;
+import team9499.commitbody.global.notification.repository.NotificationRepository;
+import team9499.commitbody.global.notification.service.FcmService;
+import team9499.commitbody.global.notification.service.NotificationService;
+import team9499.commitbody.global.redis.RedisService;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final FcmService fcmService;
+    private final NotificationRepository notificationRepository;
+    private final RedisService redisService;
+
+    /**
+     * 비동기를 통한 알림 데이터 저장
+     */
+    @Async
+    public void asyncSave(Notification notification){
+        notificationRepository.save(notification);
+    }
+
+    /**
+     * 팔로우 관련 알림 전송 메서드
+     * @param followerId    발신자
+     * @param followingId   수신자
+     */
+    @Override
+    public void sendFollowing(Long followerId, Long followingId) {
+        Member followerMember = redisService.getMemberDto(String.valueOf(followerId)).get();        // 발신자
+        Member followingMember = redisService.getMemberDto(String.valueOf(followingId)).get();      // 수신자
+        String content = followerMember.getNickname()+"님이 회원님을 팔로우하기 시작했어요.";
+
+        Notification notification = Notification.of(content, NotificationType.FOLLOW, followingMember, followerMember);
+        asyncSave(notification);        // 비동기 저장
+
+        if (followingMember.isNotificationEnabled()) // 알림성정울 true로 한 상태 일때 알림 전송
+            fcmService.sendFollowingMessage(String.valueOf(followingMember.getId()),content);
+    }
+
+}

--- a/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
@@ -54,5 +54,15 @@ public class NotificationServiceImpl implements NotificationService {
         notificationRepository.updateRead(receiverId);
     }
 
+    /**
+     * 팔로우 취소및 언팔 시에 알림 내역 삭제 메서드
+     * @param followerId    발신자
+     * @param followingId   수신자
+     */
+    @Override
+    public void deleteNotification(Long followerId, Long followingId) {
+        notificationRepository.deleteByReceiverIdAndSenderIdAndNotificationType(followingId,followerId,NotificationType.FOLLOW);
+    }
+
 
 }

--- a/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
@@ -49,4 +49,10 @@ public class NotificationServiceImpl implements NotificationService {
             fcmService.sendFollowingMessage(String.valueOf(followingMember.getId()),content);
     }
 
+    @Override
+    public void updateRead(Long receiverId) {
+        notificationRepository.updateRead(receiverId);
+    }
+
+
 }

--- a/src/main/java/team9499/commitbody/global/redis/RedisService.java
+++ b/src/main/java/team9499/commitbody/global/redis/RedisService.java
@@ -14,6 +14,7 @@ public interface RedisService {
     void deleteValue(String key);
     void setMember(Member member,Duration duration);
     Optional<Member> getMemberDto(String key);
-
     boolean nicknameLock(String key, String value,Duration duration);
+    void setFCM(String memberId, String token);
+    String getFCMToken(String key);
 }


### PR DESCRIPTION
## 개요
- 푸쉬 알림을 사용하기 위해서 Firebase를 사용한 기본 설정및 파일을 추가했습니다.
- 팔로우 요청시 팔로잉 대상자에게 푸쉬 알림이 가도록 설정
- 팔로우 취소 및 언팔시 알림 내역에서 삭제 되도록 설정
- 운동 상세 조회 로직의 버그가 발생해 버그를 수정
- 알림 일괄 읽음 처리 구현

Ref: #71

## PR 유형

- [X] 새로운 기능 추가
- [X] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [X] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [X] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).