### PR TITLE
게시글 - 댓글 수정/삭제 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/article/controller/ArticleController.java
+++ b/src/main/java/team9499/commitbody/domain/article/controller/ArticleController.java
@@ -36,7 +36,7 @@ public class ArticleController {
     private final ArticleService articleService;
 
     @Tag(name = "게시글",description = "게시글 관련 API")
-    @Operation(summary = "운동 게시글 등록", description = "운동 게시글을 작성하는 API 입니다. 관심운동 등록시에는 'articleCategory' 필드를 사용하지 않아도 됩니다.")
+    @Operation(summary = "게시글 등록", description = "게시글을 작성하는 API 입니다. 관심운동 등록시에는 'articleCategory' 필드를 사용하지 않아도 됩니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK - 게시글 작성 성공시 작성된 게시글 ID를 반환합니다.", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                     examples = @ExampleObject(value = "{\"success\":true,\"message\":\"등록 성공\",\"data\":1}"))),

--- a/src/main/java/team9499/commitbody/domain/comment/article/controller/ArticleCommentController.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/controller/ArticleCommentController.java
@@ -33,7 +33,7 @@ public class ArticleCommentController {
 
     private final ArticleCommentService articleCommentService;
 
-    @Operation(summary = "운동 게시글 - 댓글 등록", description = "운동 게시글의 댓글을 작성하는 API 입니다. (replyNickname,parentId) 필요시에만 작성합니다.",tags = "게시글")
+    @Operation(summary = "게시글 - 댓글 등록", description = "운동 게시글의 댓글을 작성하는 API 입니다. (replyNickname,parentId) 필요시에만 작성합니다.",tags = "게시글")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK - 댓글 작성시 : 댓글 작성 성공, 대댓글 작성시 : 대댓글 작성 성공", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                     examples = @ExampleObject(value = "{\"success\":true,\"message\":\"댓글 작성 성공\"}"))),
@@ -55,10 +55,22 @@ public class ArticleCommentController {
 
         return ResponseEntity.ok(new SuccessResponse<>(true,commentType));
     }
-
+    
+    @Operation(summary = "게시글 - 대/댓글 수정", description = "작성자만 작성한 댓글을 수정 가능합니다.",tags = "게시글")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"댓글 수정 성공\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 데이터 미 존재시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"해당 정보를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "타 사용자가 삭제시", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"작성자만 이용할 수 있습니다.\"}")))})
     @PutMapping("/article/comment/{commentId}")
     public ResponseEntity<?> updateComment(@PathVariable("commentId") Long commentId,
-                                           @RequestBody Map<String,String> updateComment,
+                                           @Parameter(schema = @Schema(example = "{\"content\":\"댓글 수정 내용\"}"))@RequestBody Map<String,String> updateComment,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails){
         String content = updateComment.get("content");
         Long memberId = getMemberId(principalDetails);
@@ -66,6 +78,18 @@ public class ArticleCommentController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"댓글 수정 성공"));
     }
 
+    @Operation(summary = "게시글 - 대/댓글 삭제", description = "작성자만 작성한 댓글을 삭제 가능합니다.",tags = "게시글")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"댓글 수정 성공\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 데이터 미 존재시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"해당 정보를 찾을수 없습니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}"))),
+            @ApiResponse(responseCode = "403", description = "타 사용자가 삭제시", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"작성자만 이용할 수 있습니다.\"}")))})
     @DeleteMapping("/article/comment/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long commentId,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails){
@@ -74,7 +98,7 @@ public class ArticleCommentController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"삭제 성공"));
                                            }
 
-    @Operation(summary = "운동 게시글 - 댓글 조회", description = "운동 게시글의 작성된 댓글을 조회합니다. sortOrder:[RECENT,LIKE] 이며, LIKE 정렬시 마지막 조회 데이터의 likeCount가 0일경우 lastLikeCount와 lastId를 사용하며, 0이 아닐시에는 lastLikeCount만 사용합니다.)",tags = "게시글")
+    @Operation(summary = "게시글 - 댓글 조회", description = "운동 게시글의 작성된 댓글을 조회합니다. sortOrder:[RECENT,LIKE] 이며, LIKE 정렬시 마지막 조회 데이터의 likeCount가 0일경우 lastLikeCount와 lastId를 사용하며, 0이 아닐시에는 lastLikeCount만 사용합니다.)",tags = "게시글")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                     examples = @ExampleObject(value = "{\"success\": true, \"message\": \"댓글 조회\", \"data\": {\"totalCount\" : 2,\"hasNext\": true, \"comments\": [{\"commentId\": 82, \"content\": \"댓글\", \"nickname\": \"세번쨰닉네임\", \"profile\": \"https://d12ryzjapybmlj.cloudfront.net/default.PNG\", \"time\": \"25분 전\", \"likeCount\": 0, \"replyCount\": 0, \"writer\": false}]}}"))),
@@ -95,7 +119,7 @@ public class ArticleCommentController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"댓글 조회",comments));
     }
 
-    @Operation(summary = "운동 게시글 - 대댓글 조회", description = "운동 게시글의 작성된 댓글의 대댓글을 조회합니다.",tags = "게시글")
+    @Operation(summary = "게시글 - 대댓글 조회", description = "운동 게시글의 작성된 댓글의 대댓글을 조회합니다.",tags = "게시글")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
                     examples = @ExampleObject(value = "{\"success\": true, \"message\": \"대댓글 조회\", \"data\": {\"hasNext\": false, \"comments\": [{\"commentId\": 26, \"content\": \"대댓글?\", \"nickname\": \"테스트닉네임\", \"profile\": \"https://d12ryzjapybmlj.cloudfront.net/default.PNG\", \"time\": \"5시간 전\", \"likeCount\": 0, \"writer\": true}]}}"))),

--- a/src/main/java/team9499/commitbody/domain/comment/article/controller/ArticleCommentController.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/controller/ArticleCommentController.java
@@ -23,6 +23,8 @@ import team9499.commitbody.global.authorization.domain.PrincipalDetails;
 import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
 
+import java.util.Map;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -53,6 +55,24 @@ public class ArticleCommentController {
 
         return ResponseEntity.ok(new SuccessResponse<>(true,commentType));
     }
+
+//    @PutMapping("/article/comment/{commentId}")
+//    public ResponseEntity<?> updateComment(@PathVariable("commentId") Long commentId,
+//                                           @RequestBody Map<String,String> updateComment,
+//                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+//        String content = updateComment.get("content");
+//        Long memberId = getMemberId(principalDetails);
+//        articleCommentService.updateArticleComment(memberId, commentId, content);
+//        return ResponseEntity.ok(new SuccessResponse<>(true,"댓글 수정 성공"));
+//    }
+
+    @DeleteMapping("/article/comment/{commentId}")
+    public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long commentId,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+        Long memberId = getMemberId(principalDetails);
+        articleCommentService.deleteArticleComment(memberId, commentId);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"삭제 성공"));
+                                           }
 
     @Operation(summary = "운동 게시글 - 댓글 조회", description = "운동 게시글의 작성된 댓글을 조회합니다. sortOrder:[RECENT,LIKE] 이며, LIKE 정렬시 마지막 조회 데이터의 likeCount가 0일경우 lastLikeCount와 lastId를 사용하며, 0이 아닐시에는 lastLikeCount만 사용합니다.)",tags = "게시글")
     @ApiResponses(value = {

--- a/src/main/java/team9499/commitbody/domain/comment/article/controller/ArticleCommentController.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/controller/ArticleCommentController.java
@@ -56,15 +56,15 @@ public class ArticleCommentController {
         return ResponseEntity.ok(new SuccessResponse<>(true,commentType));
     }
 
-//    @PutMapping("/article/comment/{commentId}")
-//    public ResponseEntity<?> updateComment(@PathVariable("commentId") Long commentId,
-//                                           @RequestBody Map<String,String> updateComment,
-//                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
-//        String content = updateComment.get("content");
-//        Long memberId = getMemberId(principalDetails);
-//        articleCommentService.updateArticleComment(memberId, commentId, content);
-//        return ResponseEntity.ok(new SuccessResponse<>(true,"댓글 수정 성공"));
-//    }
+    @PutMapping("/article/comment/{commentId}")
+    public ResponseEntity<?> updateComment(@PathVariable("commentId") Long commentId,
+                                           @RequestBody Map<String,String> updateComment,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails){
+        String content = updateComment.get("content");
+        Long memberId = getMemberId(principalDetails);
+        articleCommentService.updateArticleComment(memberId, commentId, content);
+        return ResponseEntity.ok(new SuccessResponse<>(true,"댓글 수정 성공"));
+    }
 
     @DeleteMapping("/article/comment/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long commentId,

--- a/src/main/java/team9499/commitbody/domain/comment/article/domain/ArticleComment.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/domain/ArticleComment.java
@@ -59,4 +59,8 @@ public class ArticleComment extends BaseTime {
     public void updateLikeCount(Integer count){
         this.likeCount = count;
     }
+
+    public void updateContent(String content){
+        this.content = content;
+    }
 }

--- a/src/main/java/team9499/commitbody/domain/comment/article/dto/ArticleCommentDto.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/dto/ArticleCommentDto.java
@@ -41,7 +41,7 @@ public class ArticleCommentDto {
 
     public static ArticleCommentDto of(ArticleComment articleComment, MemberDto memberDto, String time, boolean writer, boolean reply){
         return ArticleCommentDto.builder().commentId(articleComment.getId()).content(articleComment.getContent()).profile(memberDto.getProfile())
-                .nickname(memberDto.getNickname()).time(time).likeCount(articleComment.getLikeCount()).writer(writer).replyCount(reply ? null :articleComment.getChildComments().size()).build();
+                .nickname(memberDto.getNickname()).time(time).likeCount(articleComment.getLikeCount()).writer(writer).replyCount(reply ?articleComment.getChildComments().size(): null ).build();
     }
 
 }

--- a/src/main/java/team9499/commitbody/domain/comment/article/repository/CustomArticleCommentRepository.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/repository/CustomArticleCommentRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Slice;
 import team9499.commitbody.domain.comment.article.domain.OrderType;
 import team9499.commitbody.domain.comment.article.dto.ArticleCommentDto;
 
+import java.util.List;
+
 
 public interface CustomArticleCommentRepository {
 
@@ -13,4 +15,6 @@ public interface CustomArticleCommentRepository {
     Integer getCommentCount(Long articleId, Long memberId);
 
     Slice<ArticleCommentDto> getAllReplyComments(Long commentId, Long memberId,Long lastId ,Pageable pageable);
+
+    List<Long> getAllChildComment(Long commentId);
 }

--- a/src/main/java/team9499/commitbody/domain/comment/article/repository/CustomArticleCommentRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/repository/CustomArticleCommentRepositoryImpl.java
@@ -160,6 +160,21 @@ public class CustomArticleCommentRepositoryImpl implements CustomArticleCommentR
     }
 
     /**
+     * 부모 댓그르이 작성된 자식 댓글모두 조회
+     * @param commentId 부모 댓글 ID
+     * @return 자식댓글의 ID 리스트
+     */
+    @Override
+    public List<Long> getAllChildComment(Long commentId) {
+        List<ArticleComment> fetch = jpaQueryFactory.select(articleComment)
+                .from(articleComment)
+                .leftJoin(articleComment.childComments, childComment).fetchJoin()
+                .where(articleComment.parent.id.eq(commentId))
+                .fetch();
+        return fetch.stream().map(ArticleComment::getId).collect(Collectors.toList());
+    }
+
+    /**
      * 동적 정렬
      * - RECENT 최신순으로 정렬합니다.
      * - LIKE 좋아요 순으로 정렬합니다. 먼저 좋여가 많은순으로 정렬후 그이후 좋아요가 모두 0이라면 ID를 기준으로 내림차순 정렬 합니다.

--- a/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentBatchService.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentBatchService.java
@@ -1,0 +1,10 @@
+package team9499.commitbody.domain.comment.article.service;
+
+import java.util.List;
+
+public interface ArticleCommentBatchService {
+
+    void deleteCommentBatch(Long commentId, List<Long> ids);
+
+    void deleteChildCommentBatch(Long commentId);
+}

--- a/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentBatchServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentBatchServiceImpl.java
@@ -1,0 +1,81 @@
+package team9499.commitbody.domain.comment.article.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ArticleCommentBatchServiceImpl implements ArticleCommentBatchService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * 부모 댓글 삭제시 배치를 통한 데이터 삭제
+     * 대량의 데이터가 삭제될수 있기때문에 JPA를 사용하면 효울이 좋지않게 나올 가능성이 높아 JDBC를 통한 배치를 사용하여 대량의 데이터를 삭제하여 성능을 향상
+     * @param commentId 삭제할 부모 댓글 ID
+     * @param ids 삭제할 자식 댓글 리스트
+     */
+    @Override
+    public void deleteCommentBatch(Long commentId, List<Long> ids) {
+
+        try {
+            // content_like에서 삭제할 ID 목록 준비
+            String likeDelete = "DELETE FROM content_like WHERE article_comment_id = ?";
+            List<Object[]> likeBatchArgs = ids.stream()
+                    .map(id -> new Object[]{id})
+                    .toList();
+
+            // article_comment에서 댓글 삭제할 ID 목록 준비
+            String parentDelete = "DELETE FROM article_comment WHERE article_comment_id = ?";
+            Object[] parentArgs = {commentId};
+
+            // article_comment에서 자식 댓글 삭제할 ID 목록 준비
+            String childDelete = "DELETE FROM article_comment WHERE parent_id = ?";
+            Object[] childArgs = {commentId};
+
+            // 부모 댓글 삭제시 해당 댓글로 날라간 알림 내역 삭제
+            String notification = "DELETE FROM notification where comment_id = ?";
+            List<Object[]> notificationArgs = ids.stream()
+                    .map(id -> new Object[]{id})
+                    .toList();
+
+            // 각 테이블에서 배치 삭제 수행
+            jdbcTemplate.batchUpdate(likeDelete, likeBatchArgs);
+            jdbcTemplate.batchUpdate(notification, notificationArgs);
+            jdbcTemplate.update(parentDelete, parentArgs);
+            jdbcTemplate.update(childDelete, childArgs);
+        }catch (Exception e){
+            log.error("부모 댓글 배치 삭제시 오류 발생");
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * 자식댓글 삭제시 사용
+     * 자식 댓글 삭제시 자식댓글의 좋아요와 해당 댓글의 알림기록을 모두 삭제합니다.
+     * @param commentId 삭제할 댓글 ID
+     */
+    @Override
+    public void deleteChildCommentBatch(Long commentId) {
+        try {
+            String delChildCommentLike = "DELETE FROM content_like WHERE article_comment_id = ?";
+            String delNotification = "DELETE FROM notification WHERE comment_id = ?";
+            String delCommentId = "DELETE FROM article_comment WHERE article_comment_id = ?";
+
+            jdbcTemplate.update(delChildCommentLike, commentId);
+            jdbcTemplate.update(delNotification, commentId);
+            jdbcTemplate.update(delCommentId, commentId); 
+        }catch (Exception e){
+            log.error("자식 댓글 삭제중 오류 발생");
+            e.printStackTrace();
+        }
+        
+    }
+}

--- a/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentService.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentService.java
@@ -9,7 +9,7 @@ public interface ArticleCommentService {
 
     String saveArticleComment(Long memberId, Long ArticleId,Long commentParentId,String content,String replyNickname);
 
-//    void updateArticleComment(Long memberId, Long commentId,String content);
+    void updateArticleComment(Long memberId, Long commentId,String content);
 
     ArticleCommentResponse getComments(Long articleId, Long memberId, Long lastId, Integer lastLikeCount, OrderType orderType, Pageable pageable);
 

--- a/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentService.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentService.java
@@ -9,7 +9,12 @@ public interface ArticleCommentService {
 
     String saveArticleComment(Long memberId, Long ArticleId,Long commentParentId,String content,String replyNickname);
 
+//    void updateArticleComment(Long memberId, Long commentId,String content);
+
     ArticleCommentResponse getComments(Long articleId, Long memberId, Long lastId, Integer lastLikeCount, OrderType orderType, Pageable pageable);
 
     ArticleCommentResponse getReplyComments(Long commentId, Long memberId,Long lastId,Pageable pageable);
+
+    void deleteArticleComment(Long memberId, Long commentId);
+
 }

--- a/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/comment/article/service/ArticleCommentServiceImpl.java
@@ -16,9 +16,12 @@ import team9499.commitbody.domain.comment.article.dto.response.ArticleCommentRes
 import team9499.commitbody.domain.comment.article.repository.ArticleCommentRepository;
 import team9499.commitbody.global.Exception.ExceptionStatus;
 import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.Exception.InvalidUsageException;
 import team9499.commitbody.global.Exception.NoSuchException;
 import team9499.commitbody.global.notification.service.NotificationService;
 import team9499.commitbody.global.redis.RedisService;
+
+import java.util.List;
 
 
 @Slf4j
@@ -28,6 +31,7 @@ import team9499.commitbody.global.redis.RedisService;
 public class ArticleCommentServiceImpl implements ArticleCommentService{
 
     private final ArticleCommentRepository articleCommentRepository;
+    private final ArticleCommentBatchService articleCommentBatchService;
     private final ArticleRepository articleRepository;
     private final RedisService redisService;
     private final NotificationService notificationService;
@@ -76,6 +80,27 @@ public class ArticleCommentServiceImpl implements ArticleCommentService{
     }
 
     /**
+//     * 댓글 수정
+//     * 작성자만이 댓글을 수정 가능 비작성자 수정시 403 예외 발생
+//     * @param memberId  로그인한 사용자 ID
+//     * @param commentId 변경할 댓글 IDD
+//     * @param content 수정할 댓글 내용
+//     */
+//    @Override
+//    public void updateArticleComment(Long memberId, Long commentId,String content) {
+//        ArticleComment articleComment = articleCommentRepository.findById(commentId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+//        if (!articleComment.getMember().getId().equals(memberId)){
+//            throw new InvalidUsageException(ExceptionStatus.FORBIDDEN,ExceptionType.AUTHOR_ONLY);
+//        }
+//
+//        NotificationType notificationType  =  articleComment.getParent() == null ? NotificationType.COMMENT :NotificationType.REPLY_COMMENT;
+//        String notificationContent = articleComment.getMember().getNickname()+"님이 회원님의 게시글에 댓글을 남겼어요: "+content;
+//
+//        notificationService.updateNotification(articleComment.getMember().getId(),memberId,notificationContent,notificationType);
+//        articleComment.updateContent(content);
+//    }
+
+    /**
      * 게시글의 작성된 댓글 조회
      * @param articleId 게시글 아이디
      * @param memberId  사용자 id
@@ -104,5 +129,33 @@ public class ArticleCommentServiceImpl implements ArticleCommentService{
     public ArticleCommentResponse getReplyComments(Long commentId, Long memberId,Long lastId,Pageable pageable) {
         Slice<ArticleCommentDto> comments = articleCommentRepository.getAllReplyComments(commentId, memberId, lastId,pageable);
         return new ArticleCommentResponse(comments.hasNext(),comments.getContent());
+    }
+
+    /**
+     * 게시글의 작성된 댓글을 삭제합니다.
+     * 부모 댓글 삭제시 : 대댓글과, 좋아요, 댓글과 관련된 알림 기록등을 JDBC 배치를 사용해 삭제합니다.
+     * 자식 댓글 삭제시 : 해당 대댓글과 좋아요 대댓글 관련 알림 기록등을 JDBC 배치를 사용해 삭제합니다.
+     * 작성자가 아닐시 삭제 요청이오면 403 예외를 발생합니다.
+     * @param memberId 로그인한 사용자 ID
+     * @param commentId 삭제할 댓글 ID
+     */
+    @Override
+    public void deleteArticleComment(Long memberId, Long commentId) {
+        ArticleComment articleComment = articleCommentRepository.findById(commentId).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.NO_SUCH_DATA));
+        
+        //작성자가 아닐시 예외 발생
+        if (!articleComment.getMember().getId().equals(memberId)) {
+            throw new InvalidUsageException(ExceptionStatus.FORBIDDEN,ExceptionType.AUTHOR_ONLY);
+        }
+
+        // 부모 댓글을 삭제하려는 경우
+        if (articleComment.getParent()==null){
+            Article article = articleRepository.findById(articleComment.getArticle().getId()).get();       // 작성된 게시글의 객체를 조호
+            article.updateCommentCount(article.getCommentCount()-1);  // 부모 댓글 삭제시에는 게시글의 작성된 댓글수 -1
+            List<Long> deleteIds = articleCommentRepository.getAllChildComment(commentId);  // 작성된 댓글의 대댓글의 ID를 리스트화
+            articleCommentBatchService.deleteCommentBatch(commentId,deleteIds); // 배치를 통해 댓글과 관련된 모든 데이터 삭제
+        }else { // 대댓글을 삭제하는 경우
+            articleCommentBatchService.deleteChildCommentBatch(commentId);
+        }
     }
 }

--- a/src/main/java/team9499/commitbody/global/notification/domain/Notification.java
+++ b/src/main/java/team9499/commitbody/global/notification/domain/Notification.java
@@ -5,6 +5,8 @@ import lombok.*;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.global.utils.BaseTime;
 
+import static ch.qos.logback.classic.spi.ThrowableProxyVO.build;
+
 @Data
 @Entity
 @Builder
@@ -34,7 +36,16 @@ public class Notification extends BaseTime {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member sender;      // 발신자
 
-    public static Notification of(String content,NotificationType notificationType,Member receiver,Member sender){
-        return Notification.builder().content(content).notificationType(notificationType).receiver(receiver).sender(sender).isRead(0).build();
+    private Long commentId;     // 댓글 ID
+
+    public static Notification of(String content,NotificationType notificationType,Member receiver,Member sender,Long commentId){
+        NotificationBuilder notificationBuilder = Notification.builder().content(content).notificationType(notificationType).receiver(receiver).sender(sender).isRead(0);
+        if (content!=null)  notificationBuilder.commentId(commentId); // 댓글의 대한 알림일 경우
+        
+        return notificationBuilder.build();
+    }
+
+    public void updateContent(String content){
+        this.content = content;
     }
 }

--- a/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
@@ -20,4 +20,6 @@ public interface NotificationRepository extends JpaRepository<Notification,Long>
     void deleteByReceiverIdAndSenderIdAndNotificationType(Long receiverId, Long senderId, NotificationType notificationType);
 
     boolean existsByReceiverIdAndIsRead(Long receiverId, Integer isRead);
+
+    Notification findByCommentId(Long commentId);
 }

--- a/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
@@ -1,7 +1,6 @@
 package team9499.commitbody.global.notification.service;
 
 import team9499.commitbody.domain.Member.domain.Member;
-import team9499.commitbody.global.notification.domain.NotificationType;
 
 public interface NotificationService {
 
@@ -20,4 +19,6 @@ public interface NotificationService {
     void sendArticleLike(Member member, Long receiverId,Long articleId, boolean status);
 
     void sendCommentLike(Member member,Long receiverId,Long commentId,boolean status);
+
+    void updateNotification(Long commentId, String content);
 }

--- a/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
@@ -36,6 +36,12 @@ public class NotificationServiceImpl implements NotificationService {
         notificationRepository.save(notification);
     }
 
+    /**
+     * 비동기를 통한 팔로워 삭제
+     * @param receiverId 수신자 ID
+     * @param senderId  발신자 ID
+     * @param notificationType  알림 타입 
+     */
     @Async
     public void asyncDelete(Long receiverId, Long senderId, NotificationType notificationType){
         notificationRepository.deleteByReceiverIdAndSenderIdAndNotificationType(receiverId,senderId,notificationType);
@@ -59,6 +65,10 @@ public class NotificationServiceImpl implements NotificationService {
             fcmService.sendFollowingMessage(String.valueOf(followingMember.getId()),content);
     }
 
+    /**
+     * 알림의 일괄 읽음 처리를 하는 메서드
+     * @param receiverId 발신자 ID
+     */
     @Override
     public void updateRead(Long receiverId) {
         notificationRepository.updateRead(receiverId);
@@ -84,6 +94,14 @@ public class NotificationServiceImpl implements NotificationService {
         return notificationRepository.existsByReceiverIdAndIsRead(memberId, 0);
     }
 
+    /**
+     * 비동기를 통해 댓글의 답글이 달릴때 멘션한 사용자에게 알림을 전송합니다.
+     * @param member 발신자 사용자 객체
+     * @param replyNickname 수신자 닉네임
+     * @param articleTitle  게시글 제목
+     * @param commentContent    답글 내용
+     * @param commentId 댓글 ID
+     */
     @Async
     @Override
     public void sendReplyComment(Member member, String replyNickname,String articleTitle,String commentContent,String commentId) {
@@ -96,6 +114,14 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
+    /**
+     * 비동기를 통한 게시글의 댓글이 달릴시 게시글 작성자에게 댓글 알림을 전송합니다.
+     * @param member    발신자 정보 객체
+     * @param receiverId    수신자 ID
+     * @param articleTitle  게시글 제목
+     * @param commentContent    댓글 내용
+     * @param commentId 댓글 ID
+     */
     @Async
     @Override
     public void sendComment(Member member,Long receiverId,String articleTitle, String commentContent,String commentId) {
@@ -132,6 +158,7 @@ public class NotificationServiceImpl implements NotificationService {
         }
 
     }
+    
     @Override
     public void sendCommentLike(Member member, Long receiverId,Long commentId,boolean status) {
         Member receiverMember = getReceiverMember(receiverId);
@@ -145,15 +172,21 @@ public class NotificationServiceImpl implements NotificationService {
         }
     }
 
-//
-//    @Async
-//    @Override
-//    public void updateNotification(Long receiverId, Long senderId, String content, NotificationType notificationType) {
-//        if (!receiverId.equals(senderId)) {
-//            Notification notification = notificationRepository.findByReceiverIdAndSenderIdAndNotificationType(receiverId, senderId, notificationType).orElse(null);
-//            if (notification != null) notification.updateContent(content);
-//        }
-//    }
+
+    /**
+     * 댓글 수정시 알림의 저장된 알림 내용 수정 
+     * 비동기를 통한 수정
+     * @param commentId 수정할 댓글 ID
+     * @param content   수정할 댓글 내용
+     */
+    @Async
+    @Override
+    public void updateNotification(Long commentId, String content) {
+        Notification notification = notificationRepository.findByCommentId(commentId);
+        String[] split = notification.getContent().split(":");  // 알림 내용의 : 기준으로 분리
+        notification.updateContent(split[0] +":"+ content); // 수정된 알림 내용을 저장
+
+    }
 
     private Member getReplyMember(String replyNickname) {
         return memberRepository.findByNickname(replyNickname).orElseThrow(() -> new NoSuchException(ExceptionStatus.BAD_REQUEST, ExceptionType.No_SUCH_MEMBER));


### PR DESCRIPTION
## 개요
- 게시글 댓글 삭제/수정 기능을 담당하는 API 구현
- 댓/댓글 삭제시 연관된 데이터(좋아요, 알림, 댓글) 삭제
  - 삭제시 대량의 쿼리가 발생 할 것을 예상하여 JDBC 배치를 사용하여 삭제
- 댓글 수정시 댓글을 수정하며 알림의 기록된 알림 내용도 수정하도록 구현(알림 내역 수정은 비동기)
- 알림 도메인의 댓글 ID 컬럼을 추가 

Ref : #71 
Resolves: #79 

## PR 유형
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [X] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).