### PR TITLE
알림 내역 조회 API 구현및 그 외 수정

### DIFF
--- a/src/main/java/team9499/commitbody/domain/Member/service/MemberDocService.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/MemberDocService.java
@@ -5,6 +5,7 @@ import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.query_dsl.*;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.UpdateRequest;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,7 @@ import team9499.commitbody.domain.Member.repository.MemberDocRepository;
 import team9499.commitbody.domain.block.servcice.ElsBlockMemberService;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +43,26 @@ public class MemberDocService {
     @Async
     public void saveMemberDocAsync(MemberDoc memberDoc) {
         memberDocRepository.save(memberDoc);
+    }
+
+    /**
+     * 프로필 업데이트시 MemberDoc 인덱스 비동기 업데이트
+     * @param memberId 로그인한 사용자 ID
+     * @param nickname 변경한 닉네임
+     * @param profile 변경한 프로필 사진
+     */
+    @Async
+    public void updateMemberDocAsync(String memberId, String nickname, String profile){
+        Map<String,String> doc = new HashMap<>();
+        doc.put("nickname" , nickname);
+        doc.put("profile", profile);
+        
+        try{
+            UpdateRequest<Object, Object> updateRequest = UpdateRequest.of(u -> u.index(MEMBER_INDEX).id(memberId).doc(doc));
+            elasticsearchClient.update(updateRequest,Map.class);
+        }catch (Exception e){
+            log.error("엘라스틱 사용자 닉네임 변경중 업데이트 발생");
+        }
     }
 
     /**

--- a/src/main/java/team9499/commitbody/domain/Member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/Member/service/impl/MemberServiceImpl.java
@@ -9,6 +9,7 @@ import team9499.commitbody.domain.Member.domain.Gender;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.domain.Member.dto.response.MemberMyPageResponse;
 import team9499.commitbody.domain.Member.repository.MemberRepository;
+import team9499.commitbody.domain.Member.service.MemberDocService;
 import team9499.commitbody.domain.Member.service.MemberService;
 import team9499.commitbody.domain.block.servcice.BlockMemberService;
 import team9499.commitbody.domain.follow.domain.FollowType;
@@ -29,6 +30,7 @@ public class MemberServiceImpl implements MemberService {
     private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
     private final BlockMemberService blockMemberService;
+    private final MemberDocService memberDocService;
     private final S3Service s3Service;
 
 
@@ -78,6 +80,8 @@ public class MemberServiceImpl implements MemberService {
         Member member = getMember(memberId);
         String profile = s3Service.updateProfile(file, member.getProfile(),deleteProfile);
         member.updateProfile(nickname,gender,birthDay,height,weight,boneMineralDensity,bodyFatPercentage,profile);
+
+        memberDocService.updateMemberDocAsync(String.valueOf(memberId),nickname,profile);
     }
 
 

--- a/src/main/java/team9499/commitbody/domain/article/controller/ArticleController.java
+++ b/src/main/java/team9499/commitbody/domain/article/controller/ArticleController.java
@@ -37,12 +37,25 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
+    @Operation(summary = "게시글 조회", description = "작성된 게시글의 카테고리별로 게시글의 무한 스크롤 방식으로 조회합니다. 기본값: [type : EXERCISE, category : ALL , size : 12]",tags = "게시글")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200_1", description = "OK - 운동 인증 게시글 조회시", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"hasNext\": false, \"articles\": [{\"articleId\": 1, \"imageUrl\": \"https://d12ryzjapybmlj.cloudfront.net/images/test.png\"}]}}"))),
+            @ApiResponse(responseCode = "200_2", description = "OK - 정보 질문 게시글 조회시", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"조회 성공\", \"data\": {\"hasNext\": false, \"articles\": [{\"articleId\": 2, \"postOwner\": true, \"title\": \"게시글\", \"content\": \"내용\", \"articleCategory\": \"INFORMATION\", \"time\": \"3일 전\", \"likeCount\": 10, \"commentCount\": 0, \"imageUrl\": \"등록된 이미지가 없습니다.\", \"member\": {\"memberId\": 1, \"nickname\": \"닉네임1\", \"profile\": \"https://d12ryzjapybmlj.cloudfront.net/default.PNG\"}}]}}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 차단된 사용자 접근시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 차단한 상태입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
+
     @GetMapping("/article")
     public ResponseEntity<?> getAllArticle(@RequestParam(value = "type",required = false,defaultValue = "EXERCISE") ArticleType type,
                                            @RequestParam(value = "category",required = false,defaultValue = "ALL") ArticleCategory category,
                                            @RequestParam(value = "lastId",required = false) Long lastId,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                           @PageableDefault(size = 12) Pageable pageable
+                                           @Parameter(example = "{\"size\":12}") @PageableDefault(size = 12) Pageable pageable
                                            ){
         Long memberId = getMemberId(principalDetails);
         AllArticleResponse allArticles = articleService.getAllArticles(memberId, type, category, lastId, pageable);

--- a/src/main/java/team9499/commitbody/global/notification/controller/NotificationController.java
+++ b/src/main/java/team9499/commitbody/global/notification/controller/NotificationController.java
@@ -8,13 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import team9499.commitbody.global.authorization.domain.PrincipalDetails;
+import team9499.commitbody.global.notification.dto.response.NotificationResponse;
 import team9499.commitbody.global.notification.service.NotificationService;
 import team9499.commitbody.global.payload.ErrorResponse;
 import team9499.commitbody.global.payload.SuccessResponse;
@@ -26,6 +25,16 @@ import team9499.commitbody.global.payload.SuccessResponse;
 public class NotificationController {
 
     private final NotificationService notificationService;
+
+    @GetMapping("/notification")
+    public ResponseEntity<?> getAllNotification(@RequestParam(value = "lastId", required = false) Long lastId,
+                                                @AuthenticationPrincipal PrincipalDetails principalDetails,
+                                                Pageable pageable){
+        Long memberId = getMemberId(principalDetails);
+        NotificationResponse allNotification = notificationService.getAllNotification(memberId, lastId, pageable);
+
+        return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",allNotification));
+    }
 
     @Operation(summary = "알림 일괄 읽기", description = "알림 버튼 클릭시 현재 알림을 모두 읽기 처리합니다.")
     @ApiResponses(value = {

--- a/src/main/java/team9499/commitbody/global/notification/controller/NotificationController.java
+++ b/src/main/java/team9499/commitbody/global/notification/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package team9499.commitbody.global.notification.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -26,10 +28,18 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    @Operation(summary = "알림 목록 조회", description = "해당 사용자의 알림 내역을 조회합니다.(팔로우 알림내역에는 articleId가 존재하지 않습니다.)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value =  "{\"success\": true, \"message\": \"성공\", \"data\": {\"hasNext\": false, \"notifications\": [{\"id\": 1, \"content\": \"스웨거님이 회원님을 팔로우하기 시작했어요.\", \"time\": \"3일 전\", \"profile\": \"https://d12ryzjapybmlj.cloudfront.net/default.PNG\", \"nickname\": \"스웨거\",\"articleId\":1}]}}"))),
+            @ApiResponse(responseCode = "400", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/notification")
     public ResponseEntity<?> getAllNotification(@RequestParam(value = "lastId", required = false) Long lastId,
                                                 @AuthenticationPrincipal PrincipalDetails principalDetails,
-                                                Pageable pageable){
+                                                @Parameter(example = "{\"size\":10}") @PageableDefault Pageable pageable){
         Long memberId = getMemberId(principalDetails);
         NotificationResponse allNotification = notificationService.getAllNotification(memberId, lastId, pageable);
 

--- a/src/main/java/team9499/commitbody/global/notification/domain/Notification.java
+++ b/src/main/java/team9499/commitbody/global/notification/domain/Notification.java
@@ -9,6 +9,9 @@ import static ch.qos.logback.classic.spi.ThrowableProxyVO.build;
 
 @Data
 @Entity
+@Table(indexes = {
+        @Index(name = "idx_receiver_created",columnList = "receiver_id, created_at desc")
+})
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor
@@ -28,7 +31,7 @@ public class Notification extends BaseTime {
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;  // 알림 종류(팔로우, 댓글 , 좋아요, 전체알림)
 
-    @JoinColumn(name = "receiver_id", nullable = false)
+    @JoinColumn(name = "receiver_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     @ManyToOne(fetch = FetchType.LAZY)
     private Member receiver;      // 수신자
 

--- a/src/main/java/team9499/commitbody/global/notification/dto/NotificationDto.java
+++ b/src/main/java/team9499/commitbody/global/notification/dto/NotificationDto.java
@@ -1,0 +1,40 @@
+package team9499.commitbody.global.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+import team9499.commitbody.global.notification.domain.Notification;
+import team9499.commitbody.global.utils.TimeConverter;
+
+@Data
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NotificationDto {
+
+    private Long id;
+
+    private String content;
+
+    private String time;
+
+    private String profile;
+
+    private String nickname;
+
+    private Long articleId;
+
+    public static NotificationDto of (Notification notification){
+        NotificationDtoBuilder builder = NotificationDto.builder()
+                .id(notification.getId())
+                .content(notification.getContent())
+                .time(TimeConverter.converter(notification.getCreatedAt()))
+                .profile(notification.getReceiver().getProfile()).nickname(notification.getSender().getNickname());
+
+        if (notification.getArticleId()!=null){
+            builder.articleId(notification.getArticleId());
+        }
+        return builder.build();
+    }
+
+}

--- a/src/main/java/team9499/commitbody/global/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/team9499/commitbody/global/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,18 @@
+package team9499.commitbody.global.notification.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import team9499.commitbody.global.notification.dto.NotificationDto;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationResponse {
+
+    private boolean hasNext;
+
+    private List<NotificationDto> notifications;
+}

--- a/src/main/java/team9499/commitbody/global/notification/repository/CustomNotificationRepository.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/CustomNotificationRepository.java
@@ -1,0 +1,10 @@
+package team9499.commitbody.global.notification.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import team9499.commitbody.global.notification.dto.NotificationDto;
+
+public interface CustomNotificationRepository {
+
+    Slice<NotificationDto> getAllNotification(Long memberId, Long lastId, Pageable pageable);
+}

--- a/src/main/java/team9499/commitbody/global/notification/repository/CustomNotificationRepositoryImpl.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/CustomNotificationRepositoryImpl.java
@@ -1,0 +1,52 @@
+package team9499.commitbody.global.notification.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.Tuple;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+import team9499.commitbody.global.notification.dto.NotificationDto;
+import team9499.commitbody.global.notification.domain.Notification;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static team9499.commitbody.global.notification.domain.QNotification.*;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class CustomNotificationRepositoryImpl implements CustomNotificationRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    @Override
+    public Slice<NotificationDto> getAllNotification(Long memberId, Long lastId, Pageable pageable) {
+        BooleanBuilder lastIdBuilder = new BooleanBuilder();
+        if (lastId != null) {
+            lastIdBuilder.and(notification.id.lt(lastId));
+        }
+        List<Tuple> tupleList = jpaQueryFactory.select(notification, notification.receiver, notification.sender)
+                .from(notification)
+                .where(lastIdBuilder, notification.receiver.id.eq(memberId))
+                .limit(pageable.getPageSize() + 1)
+                .orderBy(notification.createdAt.desc())
+                .fetch();
+
+        List<NotificationDto> notificationDtoList = tupleList.stream().map(t -> NotificationDto.of(t.get(notification))).collect(Collectors.toList());
+
+        boolean hasNext = false;
+
+        if (notificationDtoList.size() > pageable.getPageSize()){
+            notificationDtoList.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(notificationDtoList,pageable,hasNext);
+    }
+}

--- a/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
+++ b/src/main/java/team9499/commitbody/global/notification/repository/NotificationRepository.java
@@ -11,7 +11,7 @@ import team9499.commitbody.global.notification.domain.NotificationType;
 import java.util.Optional;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification,Long> {
+public interface NotificationRepository extends JpaRepository<Notification,Long>,CustomNotificationRepository {
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Notification n SET n.isRead = 1 WHERE n.receiver.id IN :receiverId AND n.isRead = 0")

--- a/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/NotificationService.java
@@ -1,9 +1,12 @@
 package team9499.commitbody.global.notification.service;
 
+import org.springframework.data.domain.Pageable;
 import team9499.commitbody.domain.Member.domain.Member;
-import team9499.commitbody.domain.article.domain.Article;
+import team9499.commitbody.global.notification.dto.response.NotificationResponse;
 
 public interface NotificationService {
+
+    NotificationResponse getAllNotification(Long memberId, Long lastId, Pageable pageable);
 
     void sendFollowing(Long followerId, Long followingId);
 

--- a/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/notification/service/impl/NotificationServiceImpl.java
@@ -2,17 +2,20 @@ package team9499.commitbody.global.notification.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.domain.Member.repository.MemberRepository;
-import team9499.commitbody.domain.article.domain.Article;
 import team9499.commitbody.global.Exception.ExceptionStatus;
 import team9499.commitbody.global.Exception.ExceptionType;
 import team9499.commitbody.global.Exception.NoSuchException;
 import team9499.commitbody.global.notification.domain.Notification;
 import team9499.commitbody.global.notification.domain.NotificationType;
+import team9499.commitbody.global.notification.dto.NotificationDto;
+import team9499.commitbody.global.notification.dto.response.NotificationResponse;
 import team9499.commitbody.global.notification.repository.NotificationRepository;
 import team9499.commitbody.global.notification.service.FcmService;
 import team9499.commitbody.global.notification.service.NotificationService;
@@ -46,6 +49,21 @@ public class NotificationServiceImpl implements NotificationService {
     @Async
     public void asyncDelete(Long receiverId, Long senderId, NotificationType notificationType){
         notificationRepository.deleteByReceiverIdAndSenderIdAndNotificationType(receiverId,senderId,notificationType);
+    }
+
+    /**
+     * 알림 내역 조회
+     * @param memberId 조회할 사용자 ID
+     * @param lastId 마지막 알림 ID
+     * @param pageable  페이지 정보
+     * @return  NotificationResponse 반환
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public NotificationResponse getAllNotification(Long memberId, Long lastId, Pageable pageable) {
+        Slice<NotificationDto> allNotification = notificationRepository.getAllNotification(memberId, lastId, pageable);
+
+        return new NotificationResponse(allNotification.hasNext(),allNotification.getContent());
     }
 
     /**


### PR DESCRIPTION
## 개요
- 현재 로그인한 사용자의 알림 내역을 무한 스크롤 방식으로 조회하는 API 구현
- 사용자 프로필 수정시 사용자 검색시 사용되는 엘라스틱 MemberDoc 인덱스에소 업데이트 되도록 로직 추가
- 운동 상세 페이지 댓글 에서 차단된 차단 사용자의 댓글이 보이지 않도록 로직 수정

Ref : #81 , #76, #71
Resolves: #92 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).