### PR TITLE
최근 검색어 API 구현

### DIFF
--- a/src/main/java/team9499/commitbody/domain/article/controller/ArticleController.java
+++ b/src/main/java/team9499/commitbody/domain/article/controller/ArticleController.java
@@ -216,6 +216,16 @@ public class ArticleController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"검색 성공",allArticleResponse));
     }
 
+    @Operation(summary = "최근 검색어 - 조회", description = "최근 검색어 기록 10개를 조회합니다.",tags = "게시글")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"조회 성공\", \"data\": [\"9\", \"8\", \"7\", \"6\", \"5\", \"4\", \"3\", \"2\", \"1\"]}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 차단된 사용자 접근시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 차단한 상태입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @GetMapping("/article/search-record")
     public ResponseEntity<?> getSearchRecord(@AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = getMemberId(principalDetails);
@@ -223,14 +233,34 @@ public class ArticleController {
         return ResponseEntity.ok(new SuccessResponse<>(true,"조회 성공",recentSearchLogs));
     }
 
+    @Operation(summary = "최근 검색어 - 등록", description = "최근 검색어 기록을 등록 합니다. 최대 30개를 저장 가능하며 그이상 데이터는 마지막 데이터를 삭제하여 새롭게 저장합니다.",tags = "게시글")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"등록 성공\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 차단된 사용자 접근시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 차단한 상태입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @PostMapping("/article/search-record")
-    public ResponseEntity<?> saveSearchRecord(@RequestBody Map<String,String> searchRecordRequest,
+    public ResponseEntity<?> saveSearchRecord(@Parameter(schema = @Schema(example = "{\"title\":\"최근 검색어\"}"))@RequestBody Map<String,String> searchRecordRequest,
                                               @AuthenticationPrincipal PrincipalDetails principalDetails){
         Long memberId = getMemberId(principalDetails);
         redisService.setRecentSearchLog(String.valueOf(memberId),searchRecordRequest.get("title"));
         return ResponseEntity.ok(new SuccessResponse<>(true,"등록 성공"));
     }
 
+    @Operation(summary = "최근 검색어 - 삭제", description = "최근 검색어 기록을 삭제 합니다. 선택 삭제시에는 title 사용, 전체 삭제시에는 type의 all을 사용합니다.",tags = "게시글")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = SuccessResponse.class),
+                    examples = @ExampleObject(value = "{\"success\": true, \"message\": \"삭제 성공\"}"))),
+            @ApiResponse(responseCode = "400_1", description = "BADREQUEST - 사용 불가 토큰",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용할 수 없는 토큰입니다.\"}"))),
+            @ApiResponse(responseCode = "400_2", description = "BADREQUEST - 차단된 사용자 접근시",content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"사용자를 차단한 상태입니다.\"}"))),
+            @ApiResponse(responseCode = "401", description = "UNAUTHORIZED", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = @ExampleObject(value = "{\"success\" : false,\"message\":\"토큰이 존재하지 않습니다.\"}")))})
     @DeleteMapping("/article/search-record")
     public ResponseEntity<?> deleteSearchRecord(@RequestParam(value = "title",required = false) String title,
                                                 @RequestParam(value = "type",required = false) String type,

--- a/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
+++ b/src/main/java/team9499/commitbody/global/authorization/service/impl/AuthorizationServiceImpl.java
@@ -106,12 +106,12 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             try {
                 Member member = memberRepository.existsByNickname(nickname);
                 if (member != null) {       // 닉네임 사용자 존재시
-                    redisService.deleteValue(redisKey);
+                    redisService.deleteValue(redisKey,"인증");
                     throw new InvalidUsageException(BAD_REQUEST, DUPLICATE_NICKNAME);
                 }else       // 존재 하지 않을시 저장
                     redisService.setValues(redisKey, nickname, Duration.ofHours(1));
             } catch (Exception e) {
-                redisService.deleteValue(redisKey);
+                redisService.deleteValue(redisKey,"인증");
                 throw e;
             }
         }

--- a/src/main/java/team9499/commitbody/global/redis/RedisService.java
+++ b/src/main/java/team9499/commitbody/global/redis/RedisService.java
@@ -3,6 +3,7 @@ package team9499.commitbody.global.redis;
 import team9499.commitbody.domain.Member.domain.Member;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Optional;
 
 public interface RedisService {
@@ -13,7 +14,7 @@ public interface RedisService {
 
     String getValue(String key);
 
-    void deleteValue(String key);
+    void deleteValue(String key,String type);
 
     void setMember(Member member,Duration duration);
 
@@ -26,4 +27,10 @@ public interface RedisService {
     void setFCM(String memberId, String token);
 
     String getFCMToken(String key);
+
+    void setRecentSearchLog(String memberId, String title);
+
+    List<Object> getRecentSearchLogs(String memberId);
+
+    void deleteRecentSearchLog(String memberId, String title,String type);
 }


### PR DESCRIPTION
## 개요
- 게시글 검색시 사용자가 검색한 최근 검색어를 최대 30개까지 저장가능하며, 단일삭제 전체삭제 기능을 지원합니다.

Resolves: #97 

## PR 유형

- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [X] 주석 추가 및 수정
- [X] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).