### PR TITLE
사용자 차단 API Unit Test 및 리팩 토링 게시글 좋아요 상태 추가

### DIFF
--- a/src/main/java/team9499/commitbody/domain/article/dto/ArticleDto.java
+++ b/src/main/java/team9499/commitbody/domain/article/dto/ArticleDto.java
@@ -3,7 +3,6 @@ package team9499.commitbody.domain.article.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
-import lombok.extern.slf4j.Slf4j;
 import team9499.commitbody.domain.Member.domain.Member;
 import team9499.commitbody.domain.Member.dto.MemberDto;
 import team9499.commitbody.domain.article.domain.Article;
@@ -12,11 +11,11 @@ import team9499.commitbody.domain.article.domain.ArticleType;
 import team9499.commitbody.domain.article.domain.Visibility;
 import team9499.commitbody.domain.follow.domain.Follow;
 import team9499.commitbody.domain.follow.domain.FollowStatus;
+import team9499.commitbody.domain.like.domain.ContentLike;
 import team9499.commitbody.global.utils.TimeConverter;
 
 import java.time.LocalDateTime;
 
-@Slf4j
 @Data
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -39,6 +38,8 @@ public class ArticleDto {
     private String time;        // 작성 시간
 
     private Integer likeCount;      // 좋아요 수
+
+    private Boolean likeStatus;     // 좋아요 상태
 
     private Integer commentCount;  // 게시글 수
 
@@ -67,7 +68,7 @@ public class ArticleDto {
                 .commentCount(article.getCommentCount()).member(memberDTO).imageUrl(imageUrl).localDateTime(article.getCreatedAt()).visibility(article.getVisibility()).build();
     }
 
-    public static ArticleDto of(Long loginMemberId,Article article, String imageUrl, Follow follow){
+    public static ArticleDto of(Long loginMemberId,Article article, String imageUrl, Follow follow, ContentLike contentLike){
         Member member = article.getMember();
         ArticleDtoBuilder builder = ArticleDto.builder()
                 .articleId(article.getId())
@@ -76,6 +77,7 @@ public class ArticleDto {
                 .postOwner(loginMemberId.equals(member.getId()))
                 .imageUrl(imageUrl).followStatus(follow == null ? FollowStatus.CANCEL : follow.getStatus())
                 .likeCount(article.getLikeCount())
+                .likeStatus(contentLike != null && contentLike.isLikeStatus())
                 .member(MemberDto.builder().memberId(member.getId()).nickname(member.getNickname()).profile(member.getProfile()).build());
         if (article.getArticleType().equals(ArticleType.INFO_QUESTION)){
             builder.title(article.getTitle()).articleCategory(article.getArticleCategory()).build();

--- a/src/main/java/team9499/commitbody/domain/block/servcice/BlockMemberServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/block/servcice/BlockMemberServiceImpl.java
@@ -61,7 +61,6 @@ public class BlockMemberServiceImpl implements BlockMemberService{
      * @param blockedId 차단된 사용자
      * @return 차단하지 않았을경우 false, 차단됬을 경우 true
      */
-    @Override
     public Boolean checkBlock(Long blockerId, Long blockedId) {
         return blockMemberRepository.checkBlock(blockerId, blockedId)        // 상대방이 나를 차단했을경우
                 .map(result -> {
@@ -71,8 +70,7 @@ public class BlockMemberServiceImpl implements BlockMemberService{
                     return false; // 사용자가 차단하지 않은 경우
                 })
                 .orElseGet(() -> {
-                    boolean isBlocked = blockMemberRepository.checkBlock(blockedId, blockerId).orElse(false);   //내가 상대방을 차단했을경우
-                    return isBlocked ? true : false; // 상대방을 차단했을경우 true 차단하지 않았을 경우 false
+                    return blockMemberRepository.checkBlock(blockedId, blockerId).orElse(false);   //내가 상대방을 차단했을경우
                 });
     }
 }

--- a/src/main/java/team9499/commitbody/domain/block/servcice/ElsBlockMemberServiceImpl.java
+++ b/src/main/java/team9499/commitbody/domain/block/servcice/ElsBlockMemberServiceImpl.java
@@ -26,6 +26,13 @@ public class ElsBlockMemberServiceImpl implements ElsBlockMemberService{
     private final ElasticsearchClient elasticsearchClient;
 
     private String BLOCKED="blocked_";
+
+    /**
+     * 차단 성공/해제시 BlockMember 의 차단한 사용자 필드의 차단한 사용자 Id 를 삽입/삭제 하는 메서드
+     * @param blockerId 차단한 사용자
+     * @param blockedId 차단당한 사용자
+     * @param status   [차단 성공, 차단 해제]
+     */
     @Async
     public void blockMember(Long blockerId, Long blockedId, String status) {
         String id = getElsId(blockedId);
@@ -47,6 +54,11 @@ public class ElsBlockMemberServiceImpl implements ElsBlockMemberService{
         elsBlockMemberRepository.save(blockMemberDoc);
     }
 
+    /**
+     * 차단당한 사용자의 차단한 사용자의 ID를 조회
+     * @param blockedId 차단당한 사용자의 ID
+     * @return 차단한 사용자가 있을시 List 반환 없을시 빈 List 반환
+     */
     @Override
     public List<Long> getBlockerIds(Long blockedId) {
         String elsId = getElsId(blockedId);

--- a/src/test/java/team9499/commitbody/domain/block/controller/BlockMemberControllerTest.java
+++ b/src/test/java/team9499/commitbody/domain/block/controller/BlockMemberControllerTest.java
@@ -1,0 +1,97 @@
+package team9499.commitbody.domain.block.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.aop.AopAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import team9499.commitbody.config.SecurityTestConfig;
+import team9499.commitbody.domain.block.event.CancelBlockMemberEvent;
+import team9499.commitbody.domain.block.event.ElsBlockMemberEvent;
+import team9499.commitbody.domain.block.servcice.BlockMemberService;
+import team9499.commitbody.global.aop.AspectAdvice;
+import team9499.commitbody.global.aop.Pointcuts;
+import team9499.commitbody.mock.MockUser;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@Import({SecurityTestConfig.class, Pointcuts.class, AspectAdvice.class})
+@WebMvcTest(BlockMemberController.class)
+@ImportAutoConfiguration(AopAutoConfiguration.class)
+class BlockMemberControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockBean private BlockMemberService blockMemberService;
+    @MockBean private ApplicationEventPublisher eventPublisher;
+
+    private final ObjectMapper ob = new ObjectMapper();
+
+
+    private final Long blockerId = 1L;
+    private final Long blockedId = 2L;
+    private final String success = "차단 성공";
+    private final String fail = "차단 실패";
+
+    @DisplayName("사용자 차단 API - 차단 성공시")
+    @MockUser
+    @Test
+    void blockMemberAPI() throws Exception {
+
+        Map<String,String> request = Map.of("blockedId","2");
+
+        given(blockMemberService.blockMember(eq(blockerId),eq(blockedId))).willReturn(success);
+
+        eventPublisher.publishEvent(new ElsBlockMemberEvent(blockerId,blockedId,success));
+        eventPublisher.publishEvent(new CancelBlockMemberEvent(blockerId, blockedId, success));
+
+        mockMvc.perform(post("/api/v1/block/member")
+                        .with(csrf())
+                        .content(ob.writeValueAsString(request).getBytes(StandardCharsets.UTF_8))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(success));
+
+        verify(eventPublisher).publishEvent(any(ElsBlockMemberEvent.class));
+        verify(eventPublisher).publishEvent(any(CancelBlockMemberEvent.class));
+    }
+
+    @DisplayName("사용자 차단 API - 차단 해제시")
+    @MockUser
+    @Test
+    void unblockMemberAPI() throws Exception {
+
+        Map<String,String> request = Map.of("blockedId","2");
+
+        given(blockMemberService.blockMember(eq(blockerId),eq(blockedId))).willReturn(fail);
+
+        eventPublisher.publishEvent(new ElsBlockMemberEvent(blockerId,blockedId,fail));
+        eventPublisher.publishEvent(new CancelBlockMemberEvent(blockerId, blockedId, fail));
+
+        mockMvc.perform(post("/api/v1/block/member")
+                        .with(csrf())
+                        .content(ob.writeValueAsString(request).getBytes(StandardCharsets.UTF_8))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(fail));
+
+        verify(eventPublisher).publishEvent(any(ElsBlockMemberEvent.class));
+        verify(eventPublisher).publishEvent(any(CancelBlockMemberEvent.class));
+    }
+
+}

--- a/src/test/java/team9499/commitbody/domain/block/repository/BlockMemberRepositoryTest.java
+++ b/src/test/java/team9499/commitbody/domain/block/repository/BlockMemberRepositoryTest.java
@@ -1,0 +1,63 @@
+package team9499.commitbody.domain.block.repository;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import team9499.commitbody.domain.Member.domain.LoginType;
+import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.domain.Member.repository.MemberRepository;
+import team9499.commitbody.domain.block.domain.BlockMember;
+import team9499.commitbody.global.config.QueryDslConfig;
+
+import static org.assertj.core.api.Assertions.*;
+
+@Slf4j
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@ActiveProfiles("test")
+class BlockMemberRepositoryTest {
+
+    @Autowired private BlockMemberRepository blockMemberRepository;
+    @Autowired private MemberRepository memberRepository;
+
+
+    private Long blockerId;
+    private Long blockedId;
+
+    @BeforeEach
+    void init(){
+        Member blocker = memberRepository.save(Member.builder().nickname("차단한 사용자").socialId("1231151").loginType(LoginType.KAKAO).build());
+        Member blocked = memberRepository.save(Member.builder().nickname("차단 당한 사용자").socialId("66666").loginType(LoginType.KAKAO).build());
+        blockMemberRepository.save(BlockMember.of(blocker,blocked));
+
+        blockerId = blocker.getId();
+        blockedId = blocked.getId();
+    }
+
+    @DisplayName("차단된 사용자 조회")
+    @Test
+    void findByBlockMemberById(){
+
+        BlockMember blockMember = blockMemberRepository.findByBlockerIdAndBlockedId(blockerId, blockedId);
+
+        assertThat(blockMember.getBlocker().getNickname()).isEqualTo("차단한 사용자");
+        assertThat(blockMember.getBlocked().getNickname()).isEqualTo("차단 당한 사용자");
+    }
+    
+    @DisplayName("사용자를 차단했는제 체크")
+    @Test
+    void checkBlockMember(){
+
+        Boolean falseBlock = blockMemberRepository.checkBlock(blockerId, blockerId).orElse(false);
+        Boolean trueBlock = blockMemberRepository.checkBlock(blockerId, blockedId).orElse(false);
+
+        assertThat(falseBlock).isFalse();
+        assertThat(trueBlock).isTrue();
+    }
+
+}

--- a/src/test/java/team9499/commitbody/domain/block/servcice/BlockMemberServiceTest.java
+++ b/src/test/java/team9499/commitbody/domain/block/servcice/BlockMemberServiceTest.java
@@ -1,0 +1,95 @@
+package team9499.commitbody.domain.block.servcice;
+
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team9499.commitbody.domain.Member.domain.LoginType;
+import team9499.commitbody.domain.Member.domain.Member;
+import team9499.commitbody.domain.block.domain.BlockMember;
+import team9499.commitbody.domain.block.repository.BlockMemberRepository;
+import team9499.commitbody.global.Exception.BlockException;
+import team9499.commitbody.global.Exception.ExceptionStatus;
+import team9499.commitbody.global.Exception.ExceptionType;
+import team9499.commitbody.global.redis.RedisService;
+
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class BlockMemberServiceTest {
+
+    @Mock private BlockMemberRepository blockMemberRepository;
+    @Mock private RedisService redisService;
+
+    @InjectMocks private BlockMemberServiceImpl blockMemberService;
+
+    private Long blockerId = 1L;
+    private Long blockedId = 2L;
+
+    @DisplayName("차단 해제 테스트")
+    @Test
+    void UnBlockMember() {
+        Member blocker = Member.builder().id(blockerId).nickname("차단한 사용자").loginType(LoginType.KAKAO).build();
+        Member blocked = Member.builder().id(blockedId).nickname("차단 당한 사용자").loginType(LoginType.KAKAO).build();
+        BlockMember blockMember = BlockMember.of(blocker, blocked);
+
+        when(redisService.getMemberDto(eq(blockerId.toString()))).thenReturn(Optional.of(blocker));
+        when(redisService.getMemberDto(eq(blockedId.toString()))).thenReturn(Optional.of(blocked));
+        when(blockMemberRepository.findByBlockerIdAndBlockedId(eq(blockerId),eq(blockedId))).thenReturn(blockMember);
+
+        String status = blockMemberService.blockMember(blockerId, blockedId);
+        
+        assertThat(status).isEqualTo("차단 해제");
+
+    }
+
+
+    @DisplayName("차단 등록 테스트")
+    @Test
+    void BlockMember() {
+        Member blocker = Member.builder().id(blockerId).nickname("차단한 사용자").loginType(LoginType.KAKAO).build();
+        Member blocked = Member.builder().id(blockedId).nickname("차단 당한 사용자").loginType(LoginType.KAKAO).build();
+        BlockMember blockMember = BlockMember.of(blocker, blocked);
+
+        when(redisService.getMemberDto(eq(blockerId.toString()))).thenReturn(Optional.of(blocker));
+        when(redisService.getMemberDto(eq(blockedId.toString()))).thenReturn(Optional.of(blocked));
+        when(blockMemberRepository.findByBlockerIdAndBlockedId(eq(blockerId),eq(blockedId))).thenReturn(null);
+        when(blockMemberRepository.save(eq(blockMember))).thenReturn(blockMember);
+
+        String status = blockMemberService.blockMember(blockerId, blockedId);
+
+        assertThat(status).isEqualTo("차단 성공");
+
+    }
+
+    
+    @DisplayName("차단 상태 - 차단한 경우 예외 발생")
+    @Test
+    void checkBlockMember(){
+        when(blockMemberRepository.checkBlock(anyLong(),anyLong())).thenThrow(new BlockException(ExceptionStatus.BAD_REQUEST, ExceptionType.BLOCK));
+
+       assertThatThrownBy(() -> blockMemberService.checkBlock(blockerId,blockedId))
+               .isInstanceOf(BlockException.class)
+               .hasMessage("사용자를 차단한 상태입니다.");
+    }
+
+    @DisplayName("차단 상태 - 내가 상대방을 차단했을 경우 true 반환")
+    @Test
+    void checkBlockWhenIBlockedTheOtherMember() {
+        when(blockMemberRepository.checkBlock(eq(blockerId), eq(blockedId))).thenReturn(Optional.empty());
+        when(blockMemberRepository.checkBlock(eq(blockedId), eq(blockerId))).thenReturn(Optional.of(true));
+
+        boolean isBlocked = blockMemberService.checkBlock(blockerId, blockedId);
+
+        assertThat(isBlocked).isTrue();
+    }
+
+
+}

--- a/src/test/java/team9499/commitbody/domain/block/servcice/ElsBlockMemberServiceTest.java
+++ b/src/test/java/team9499/commitbody/domain/block/servcice/ElsBlockMemberServiceTest.java
@@ -1,0 +1,118 @@
+package team9499.commitbody.domain.block.servcice;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team9499.commitbody.domain.block.domain.BlockMemberDoc;
+import team9499.commitbody.domain.block.repository.ElsBlockMemberRepository;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Slf4j
+@ExtendWith(MockitoExtension.class)
+class ElsBlockMemberServiceTest {
+
+    @Mock private ElsBlockMemberRepository blockMemberRepository;
+    @Mock private ElasticsearchClient elasticsearchClient;
+
+    @InjectMocks private ElsBlockMemberServiceImpl blockMemberService;
+
+    private Long blockerId = 1L;
+    private Long blockedId = 2L;
+
+    @DisplayName("차단 성공시 List에 차단한 사용자 추가")
+    @Test
+    void blockMember(){
+
+        BlockMemberDoc blockMemberDoc = BlockMemberDoc.builder().id("2").blockerId(new ArrayList<>()).build();
+
+        when(blockMemberRepository.findById(eq("blocked_2"))).thenReturn(Optional.of(blockMemberDoc));
+        when(blockMemberRepository.save(any())).thenReturn(blockMemberDoc);
+        
+        blockMemberService.blockMember(blockerId,blockedId,"차단 성공");
+
+        assertThat(blockMemberDoc.getBlockerId()).contains(blockerId);
+    }
+    
+    @DisplayName("차단 해제시 차단한 사용자 제거")
+    @Test
+    void UnBlockRemove(){
+        List<Long> blockedIds = new ArrayList<>();
+        blockedIds.add(1L);
+        BlockMemberDoc blockMemberDoc = BlockMemberDoc.builder().id("2").blockerId(blockedIds).build();
+
+        when(blockMemberRepository.findById(eq("blocked_2"))).thenReturn(Optional.of(blockMemberDoc));
+        when(blockMemberRepository.save(any())).thenReturn(blockMemberDoc);
+
+        blockMemberService.blockMember(blockerId,blockedId,"차단 해제");
+
+        assertThat(blockMemberDoc.getBlockerId()).doesNotContain(blockerId);
+    }
+
+    @DisplayName("차단당한 사용자를 차단한 사용자 ID 값 조회")
+    @Test
+    void blockedByBlockerIds(){
+        List<Long> blockedIds = new ArrayList<>();
+        blockedIds.add(1L);
+        blockedIds.add(3L);
+        blockedIds.add(4L);
+        BlockMemberDoc blockMemberDoc = BlockMemberDoc.builder().id("2").blockerId(blockedIds).build();
+
+        when(blockMemberRepository.findById("blocked_2")).thenReturn(Optional.of(blockMemberDoc));
+
+        List<Long> blockerIds = blockMemberService.getBlockerIds(blockedId);
+
+        assertThat(blockerIds.size()).isEqualTo(3);
+        assertThat(blockerIds).containsAll(List.of(1L,3L,4L));
+    }
+    
+    
+    @DisplayName("차단한 사용자가 차단된 사용자의 ID값을 조회")
+    @Test
+    void blockerByBlockedIds() throws IOException {
+
+        SearchResponse<Object> searchResponse = mock(SearchResponse.class);
+
+        List<Hit<Object>> mockHitList = new ArrayList<>();
+
+        Hit<Object> mockHit1 = mock(Hit.class);
+        Hit<Object> mockHit2 = mock(Hit.class);
+
+        when(mockHit1.id()).thenReturn("blocked_2");
+        when(mockHit2.id()).thenReturn("blocked_3");
+
+        mockHitList.add(mockHit1);
+        mockHitList.add(mockHit2);
+
+        HitsMetadata hitsMetadata = mock(HitsMetadata.class);
+        when(hitsMetadata.hits()).thenReturn(mockHitList);
+        when(searchResponse.hits()).thenReturn(hitsMetadata);
+
+
+        when(elasticsearchClient.search(any(SearchRequest.class),any())).thenReturn(searchResponse);
+
+        List<Long> blockedIds = blockMemberService.findBlockedIds(blockerId);
+
+        assertThat(blockedIds.size()).isEqualTo(2);
+        assertThat(blockedIds).containsAll(List.of(2L,3L));
+
+        verify(elasticsearchClient,times(1)).search(any(SearchRequest.class),any());
+    }
+
+}


### PR DESCRIPTION
## 개요
- 게시글을 상세 조회할때 사용자가 좋아요했는지 확인할수 있는 likeStatus 필드 추가 및 조회 쿼리시 join 조건 추가
- 사용자 차단 API의 대해서 메서드 기능별 단위 테스트 작성
- 사용자 차단 단위 테스트 작성시 코드 리팩토링 및 주석 추가

Resolves: #110 

## PR 유형
- [X] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [X] 코드 리팩토링
- [X] 주석 추가 및 수정
- [ ] 문서 수정
- [X] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).